### PR TITLE
fix: apply preview alignment changes to already-rendered previews

### DIFF
--- a/docs/MANUAL_TESTS.md
+++ b/docs/MANUAL_TESTS.md
@@ -21,6 +21,8 @@ Run in a desktop test vault after `npm run build` and copying the plugin (or sym
 
 ## Settings / theming
 - [ ] Switching Obsidian dark/light updates the editor theme on the next editor open.
+- [ ] Changing "Preview alignment" realigns already-rendered previews immediately (no re-render), including in a popped-out window.
+- [ ] Disabling the plugin removes the left-alignment (previews in still-open notes fall back to centered).
 - [ ] "Custom URL" mode loads the editor from the configured URL (e.g. https://embed.diagrams.net/).
 - [ ] Server idle timeout persists across reloads; values below 5 are rejected.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,17 @@ export default class DrawioPlugin extends Plugin {
     const { registerDrawioEmbeds } = await import('./file/EmbedRenderer');
     registerDrawioEmbeds(this);
 
+    // Preview alignment is a body-level class (see styles.css), so flipping
+    // the setting realigns already-rendered previews — including ones Obsidian
+    // keeps cached and detached — without waiting for a re-render. New popout
+    // windows get the class on creation; unload clears it everywhere.
+    this.applyPreviewAlignment();
+    this.registerEvent(this.app.workspace.on('window-open', (_win, popoutWin) => {
+      popoutWin.document.body.classList.toggle(
+        'drawio-align-left', this.settings.previewAlignment === 'left');
+    }));
+    this.register(() => setPreviewAlignmentClass(this, false));
+
     await maybeRegisterDesktopFeatures(this);
 
     const { DrawioSettingTab } = await import('./settingsTab');
@@ -100,8 +111,12 @@ export default class DrawioPlugin extends Plugin {
   previewOpts(): RenderOptions {
     return {
       dark: this.settings.followObsidianTheme && this.isDark(),
-      align: this.settings.previewAlignment,
     };
+  }
+
+  /** Sync the body-level alignment class with the current setting. */
+  applyPreviewAlignment() {
+    setPreviewAlignmentClass(this, this.settings.previewAlignment === 'left');
   }
 
   /** Shared deps for any DrawioEditor surface (modal or inline file view).
@@ -134,6 +149,18 @@ export default class DrawioPlugin extends Plugin {
   updateServerIdleTimeout() {
     this.server?.setIdleMs(this.settings.serverIdleTimeout * 1000);
   }
+}
+
+/** Toggle the `drawio-align-left` class on every window's body (main window
+ * plus any popouts, found via their leaves). Alignment lives on the body so a
+ * settings change takes effect on previews Obsidian has already rendered.
+ * Exported standalone so it's unit-testable without a full Plugin instance. */
+export function setPreviewAlignmentClass(plugin: DrawioPlugin, left: boolean): void {
+  const bodies = new Set<HTMLElement>([activeDocument.body]);
+  plugin.app.workspace.iterateAllLeaves((leaf) => {
+    bodies.add(leaf.view.containerEl.ownerDocument.body);
+  });
+  for (const body of bodies) body.classList.toggle('drawio-align-left', left);
 }
 
 /** Dynamically load and run desktop-only registration (local server, ribbon,

--- a/src/preview/ViewerRenderer.ts
+++ b/src/preview/ViewerRenderer.ts
@@ -1,12 +1,9 @@
 import { ensureViewerLoaded, getGraphViewer } from './loadViewer';
 import { isValidDrawioXml, ensureMxfile } from '../model/xmlUtils';
 import { sanitizeSvgToNode } from './svgSanitizer';
-import type { PreviewAlignment } from '../settings';
 
 export interface RenderOptions {
   dark: boolean;
-  /** Horizontal alignment of the rendered SVG; defaults to 'center'. */
-  align?: PreviewAlignment;
   /** Which diagram page to render (0-indexed); defaults to 0 (first page). */
   page?: number;
 }
@@ -42,7 +39,6 @@ const RENDER_TIMEOUT_MS = 5000;
  */
 export function renderPreview(el: HTMLElement, xml: string, opts: RenderOptions): boolean {
   el.empty();
-  el.classList.toggle('drawio-align-left', opts.align === 'left');
   if (!isValidDrawioXml(xml)) {
     el.createDiv({ cls: 'drawio-error', text: 'Invalid drawio diagram' });
     return false;

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -108,12 +108,16 @@ export class DrawioSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('Preview alignment')
-      .setDesc('How rendered previews (embeds and code blocks) are aligned. Applies when a note is re-rendered.')
+      .setDesc('How rendered previews (embeds and code blocks) are aligned. Takes effect immediately.')
       .addDropdown((d) => d
         .addOption('center', 'Center')
         .addOption('left', 'Left')
         .setValue(s.previewAlignment)
-        .onChange((v) => { s.previewAlignment = v as PreviewAlignment; save(); }));
+        .onChange((v) => {
+          s.previewAlignment = v as PreviewAlignment;
+          save();
+          this.plugin.applyPreviewAlignment();
+        }));
 
     new Setting(containerEl)
       .setName('Follow Obsidian theme')

--- a/styles.css
+++ b/styles.css
@@ -5,9 +5,11 @@
 /* The extracted SVG carries explicit width/height/viewBox (see ViewerRenderer),
    so it renders at its natural diagram size and scales down to fit; centre it. */
 .drawio-preview svg { max-width: 100%; height: auto; display: block; margin: 0 auto; }
-/* "Preview alignment: Left" setting. */
-.drawio-preview.drawio-align-left { text-align: left; }
-.drawio-preview.drawio-align-left svg { margin: 0; }
+/* "Preview alignment: Left" setting. Body-level (toggled by the plugin on
+   every window) so a settings change realigns already-rendered previews
+   without waiting for a re-render. */
+body.drawio-align-left .drawio-preview { text-align: left; }
+body.drawio-align-left .drawio-preview svg { margin: 0; }
 
 /* Centered, hover-revealed "Edit" hint. Non-interactive (clicks fall through to the
    preview) and centered rather than in a corner, so it never collides with other

--- a/tests/drawioCodeBlockMobile.test.ts
+++ b/tests/drawioCodeBlockMobile.test.ts
@@ -17,7 +17,7 @@ function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: 
   const raw = {
     app: {},
     settings: { previewClickAction },
-    previewOpts: () => ({ dark: false, align: 'center' as const }),
+    previewOpts: () => ({ dark: false }),
     openEditor,
     registerMarkdownCodeBlockProcessor: (_lang: string, cb: Processor) => { processor = cb; },
   };

--- a/tests/drawioPreviewFileView.test.ts
+++ b/tests/drawioPreviewFileView.test.ts
@@ -16,7 +16,7 @@ function fakePlugin(
   return {
     app,
     settings: { previewClickAction },
-    previewOpts: () => ({ dark: false, align: 'center' as const }),
+    previewOpts: () => ({ dark: false }),
     openEditor,
   } as unknown as DrawioPlugin;
 }

--- a/tests/embedRendererMobile.test.ts
+++ b/tests/embedRendererMobile.test.ts
@@ -27,7 +27,7 @@ function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: 
       openWithDefaultApp,
     },
     settings: { previewClickAction },
-    previewOpts: () => ({ dark: false, align: 'center' as const }),
+    previewOpts: () => ({ dark: false }),
     openEditor,
     register: vi.fn(),
   };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -5,7 +5,7 @@ vi.mock('../src/desktop/registerDesktopFeatures', () => ({
   registerDesktopFeatures: vi.fn(async () => {}),
 }));
 
-import { maybeRegisterDesktopFeatures } from '../src/main';
+import { maybeRegisterDesktopFeatures, setPreviewAlignmentClass } from '../src/main';
 import { registerDesktopFeatures } from '../src/desktop/registerDesktopFeatures';
 import type DrawioPlugin from '../src/main';
 
@@ -28,5 +28,44 @@ describe('maybeRegisterDesktopFeatures', () => {
     const fakePlugin = {} as unknown as DrawioPlugin;
     await maybeRegisterDesktopFeatures(fakePlugin);
     expect(registerDesktopFeatures).not.toHaveBeenCalled();
+  });
+});
+
+describe('setPreviewAlignmentClass', () => {
+  function fakePlugin(leaves: Array<{ view: { containerEl: HTMLElement } }>): DrawioPlugin {
+    return {
+      app: {
+        workspace: {
+          iterateAllLeaves: (cb: (leaf: unknown) => void) => { leaves.forEach(cb); },
+        },
+      },
+    } as unknown as DrawioPlugin;
+  }
+
+  afterEach(() => {
+    document.body.classList.remove('drawio-align-left');
+  });
+
+  it('adds the class to the main body and every popout body', () => {
+    const popoutDoc = document.implementation.createHTMLDocument();
+    const plugin = fakePlugin([
+      { view: { containerEl: document.createElement('div') } },
+      { view: { containerEl: popoutDoc.createElement('div') } },
+    ]);
+    setPreviewAlignmentClass(plugin, true);
+    expect(document.body.classList.contains('drawio-align-left')).toBe(true);
+    expect(popoutDoc.body.classList.contains('drawio-align-left')).toBe(true);
+  });
+
+  it('removes the class from every body when centered', () => {
+    const popoutDoc = document.implementation.createHTMLDocument();
+    document.body.classList.add('drawio-align-left');
+    popoutDoc.body.classList.add('drawio-align-left');
+    const plugin = fakePlugin([
+      { view: { containerEl: popoutDoc.createElement('div') } },
+    ]);
+    setPreviewAlignmentClass(plugin, false);
+    expect(document.body.classList.contains('drawio-align-left')).toBe(false);
+    expect(popoutDoc.body.classList.contains('drawio-align-left')).toBe(false);
   });
 });

--- a/tests/viewerRenderer.sizing.test.ts
+++ b/tests/viewerRenderer.sizing.test.ts
@@ -52,21 +52,6 @@ describe('renderPreview standalone-svg sizing', () => {
     expect(svg!.style.minWidth).toBe('');
   });
 
-  it('toggles the left-alignment class from opts.align', () => {
-    const el = document.createElement('div');
-    patchEl(el);
-
-    renderPreview(el, '<mxfile></mxfile>', { dark: false, align: 'left' });
-    expect(el.classList.contains('drawio-align-left')).toBe(true);
-
-    // Re-render with center (or unset) removes it again.
-    renderPreview(el, '<mxfile></mxfile>', { dark: false, align: 'center' });
-    expect(el.classList.contains('drawio-align-left')).toBe(false);
-
-    renderPreview(el, '<mxfile></mxfile>', { dark: false });
-    expect(el.classList.contains('drawio-align-left')).toBe(false);
-  });
-
   it('threads opts.page into the data-mxgraph config passed to GraphViewer', () => {
     const el = document.createElement('div');
     patchEl(el);


### PR DESCRIPTION
## Problem

Changing the **Preview alignment** setting had no effect on previews already rendered in open notes — Obsidian caches reading-view blocks and live-preview widgets, so the old per-element `drawio-align-left` class (written by `renderPreview` at render time) stuck around until the note happened to re-render. The setting description even documented the limitation ("Applies when a note is re-rendered").

## Fix

Alignment now lives as a **body-level class** instead of a per-render element class:

- `styles.css`: `body.drawio-align-left .drawio-preview { ... }` — pure CSS, so realignment needs no re-render and also covers blocks Obsidian keeps cached while detached.
- `main.ts`: new `setPreviewAlignmentClass()` toggles the class on every window's body (main + popouts, enumerated via each leaf's `ownerDocument`); applied on load, on the settings change, and on `window-open` for popouts created later; cleared everywhere on unload.
- `settingsTab.ts`: the alignment dropdown's `onChange` now calls `applyPreviewAlignment()`; description updated to "Takes effect immediately."
- `ViewerRenderer.ts`: the `align` render option is gone — one mechanism, no state to go stale.

API floors checked per the repo checklist: `window-open` (@since 0.15.3), `iterateAllLeaves` (@since 0.9.7), `View.containerEl` (@since 0.9.7) — all below `minAppVersion` 1.4.0. No new Node imports, regex literals, or script elements; mobile-safe.

## Tests

- New unit tests for `setPreviewAlignmentClass` (main body + popout bodies, add and remove).
- Removed the obsolete `renderPreview` align-class test; updated `previewOpts` stubs.
- `npm test`: 149 passed (25 files). `npm run build`: clean.
- Manual-test checklist gains two entries (live realign incl. popout; unload cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)