### PR TITLE
perf: serve the offline webapp with HTTP cache headers

### DIFF
--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -1,4 +1,4 @@
-import { createServer, Server } from 'node:http';
+import { createServer, IncomingMessage, Server } from 'node:http';
 import { createReadStream, statSync, realpathSync } from 'node:fs';
 import { join, normalize, extname, sep } from 'node:path';
 import { findFreePort } from './portDetector';
@@ -49,7 +49,7 @@ export class ServerManager {
 
   private async start(): Promise<number> {
     this.port = await findFreePort(this.opts.min, this.opts.max);
-    this.server = createServer((req, res) => this.handle(req.url ?? '/', res));
+    this.server = createServer((req, res) => this.handle(req, res));
     await new Promise<void>((resolve, reject) => {
       this.server!.once('error', reject);
       this.server!.listen(this.port, '127.0.0.1', resolve);
@@ -77,8 +77,8 @@ export class ServerManager {
     if (this.server) { this.server.close(); this.server = null; this.port = 0; }
   }
 
-  private handle(url: string, res: import('node:http').ServerResponse): void {
-    const path0 = url.split('?')[0] ?? '/';
+  private handle(req: IncomingMessage, res: import('node:http').ServerResponse): void {
+    const path0 = (req.url ?? '/').split('?')[0] ?? '/';
     let path: string;
     try {
       path = decodeURIComponent(path0);
@@ -102,15 +102,49 @@ export class ServerManager {
     if (!full.startsWith(this.realRoot + sep) && full !== this.realRoot) {
       res.writeHead(403); res.end('Forbidden'); return;
     }
-    if (!statSync(full).isFile()) {
+    const stats = statSync(full);
+    if (!stats.isFile()) {
       res.writeHead(404); res.end('Not found'); return;
     }
+
+    // The webapp is a pinned, immutable artifact (scripts/fetch-drawio.mjs), so
+    // responses are safely cacheable. Without these headers Chromium re-fetches
+    // the whole webapp on every editor mount AND never engages V8's code cache
+    // for app.min.js — re-parsing it dominates the editor's startup delay.
+    // Validators (ETag/Last-Modified) keep post-expiry revalidation a cheap
+    // loopback 304, which preserves the cached entry (and its code cache); a
+    // fetch-drawio version bump changes mtime, so the ETag busts stale copies.
+    const etag = `"${stats.size}-${stats.mtimeMs}"`;
+    const cacheHeaders = {
+      'Cache-Control': 'public, max-age=3600',
+      'ETag': etag,
+      'Last-Modified': stats.mtime.toUTCString(),
+    };
+    if (this.isNotModified(req, etag, stats.mtimeMs)) {
+      res.writeHead(304, cacheHeaders); res.end(); return;
+    }
+
     const stream = createReadStream(full);
     stream.on('error', () => {
       if (!res.headersSent) res.writeHead(500);
       res.end('Internal Server Error');
     });
-    res.writeHead(200, { 'Content-Type': MIME[extname(full)] ?? 'application/octet-stream' });
+    res.writeHead(200, {
+      'Content-Type': MIME[extname(full)] ?? 'application/octet-stream',
+      'Content-Length': String(stats.size),
+      ...cacheHeaders,
+    });
     stream.pipe(res);
+  }
+
+  /** Conditional-request check: If-None-Match wins over If-Modified-Since (RFC 9110). */
+  private isNotModified(req: IncomingMessage, etag: string, mtimeMs: number): boolean {
+    const inm = req.headers['if-none-match'];
+    if (inm) return inm === '*' || inm.split(',').some((t) => t.trim() === etag);
+    const ims = req.headers['if-modified-since'];
+    if (!ims) return false;
+    const since = Date.parse(ims);
+    // HTTP dates have 1s granularity; truncate mtime the same way for the compare.
+    return !Number.isNaN(since) && Math.floor(mtimeMs / 1000) * 1000 <= since;
   }
 }

--- a/tests/serverManager.test.ts
+++ b/tests/serverManager.test.ts
@@ -99,4 +99,66 @@ describe('ServerManager', () => {
     const res = await fetch(`http://127.0.0.1:${port}/link.txt`);
     expect(res.status).toBe(403);
   });
+
+  // The cache tests below each get their own port range: fetch() (undici)
+  // pools keep-alive connections per origin, and reusing a pooled socket
+  // against a *restarted* server on the same port flakes with
+  // "other side closed".
+
+  it('serves cacheable responses with validators', async () => {
+    mgr = new ServerManager(fakeWebapp(), { min: 41210, max: 41219, idleMs: 60000 });
+    const port = await mgr.ensureStarted();
+    const res = await fetch(`http://127.0.0.1:${port}/index.html`);
+    expect(res.headers.get('cache-control')).toBe('public, max-age=3600');
+    expect(res.headers.get('etag')).toMatch(/^".+"$/);
+    expect(res.headers.get('last-modified')).toBeTruthy();
+    expect(res.headers.get('content-length')).toBe(String((await res.arrayBuffer()).byteLength));
+  });
+
+  it('answers a matching If-None-Match with 304 and no body', async () => {
+    mgr = new ServerManager(fakeWebapp(), { min: 41220, max: 41229, idleMs: 60000 });
+    const port = await mgr.ensureStarted();
+    const first = await fetch(`http://127.0.0.1:${port}/index.html`);
+    const etag = first.headers.get('etag')!;
+    const second = await fetch(`http://127.0.0.1:${port}/index.html`, {
+      headers: { 'If-None-Match': etag },
+      cache: 'no-store',
+    });
+    expect(second.status).toBe(304);
+    expect(second.headers.get('etag')).toBe(etag);
+    expect(await second.text()).toBe('');
+  });
+
+  it('answers a fresh If-Modified-Since with 304 and a stale one with 200', async () => {
+    mgr = new ServerManager(fakeWebapp(), { min: 41230, max: 41239, idleMs: 60000 });
+    const port = await mgr.ensureStarted();
+    const first = await fetch(`http://127.0.0.1:${port}/index.html`);
+    const lastModified = first.headers.get('last-modified')!;
+    const fresh = await fetch(`http://127.0.0.1:${port}/index.html`, {
+      headers: { 'If-Modified-Since': lastModified },
+      cache: 'no-store',
+    });
+    expect(fresh.status).toBe(304);
+    const stale = await fetch(`http://127.0.0.1:${port}/index.html`, {
+      headers: { 'If-Modified-Since': new Date(Date.parse(lastModified) - 60_000).toUTCString() },
+      cache: 'no-store',
+    });
+    expect(stale.status).toBe(200);
+  });
+
+  it('serves 200 with fresh validators when the file changes (version bump)', async () => {
+    const root = fakeWebapp();
+    mgr = new ServerManager(root, { min: 41240, max: 41249, idleMs: 60000 });
+    const port = await mgr.ensureStarted();
+    const first = await fetch(`http://127.0.0.1:${port}/index.html`);
+    const etag = first.headers.get('etag')!;
+    writeFileSync(join(root, 'index.html'), '<html>drawio v2 — longer body</html>');
+    const second = await fetch(`http://127.0.0.1:${port}/index.html`, {
+      headers: { 'If-None-Match': etag },
+      cache: 'no-store',
+    });
+    expect(second.status).toBe(200);
+    expect(second.headers.get('etag')).not.toBe(etag);
+    expect(await second.text()).toContain('v2');
+  });
 });


### PR DESCRIPTION
## 问题

在 offline（内置 webapp）模式下，每次打开 `.drawio` 文件都会新建 iframe 并从零引导整个 drawio webapp，加载动画覆盖的正是这段引导期。本地服务器的响应只带 `Content-Type`，没有任何缓存头——Chromium 既不能复用 HTTP 缓存（每次全量重传 webapp），也无法为 `app.min.js` 启用 V8 code cache（重复解析编译是启动延迟的大头）。

## 改动

- `ServerManager` 响应附加 `Cache-Control: public, max-age=3600`、`ETag`（size + mtime）、`Last-Modified` 与 `Content-Length`。
- 支持条件请求：`If-None-Match` / `If-Modified-Since` 命中时返回 304（无响应体），过期后的再验证只是一次廉价的回环 304，且保留缓存条目及其 code cache。
- webapp 是版本锁定（v30.0.4）的不可变产物，端口探测从固定的 `serverPortMin` 顺序扫描（实际端口稳定），因此按 origin 键控的缓存可跨服务器空闲重启存活；`fetch-drawio` 版本升级会改变 mtime/size，自动使 ETag 失效。

## 预期效果

第二次打开起命中 HTTP 缓存，若干次后 V8 code cache 生效，编辑器引导时间显著缩短（加载动画只会一闪而过）。首次冷启动不受影响。

## 测试

- 新增 4 项单测：缓存头与验证器、`If-None-Match` → 304、`If-Modified-Since` 新旧对比（304 / 200）、文件变更后 ETag 失效返回 200。
- 各缓存测试使用独立端口段，避免 undici 跨已重启服务器复用池化 keep-alive 连接造成的偶发失败。
- 全套 152 项测试通过；`npm run build`（tsc + esbuild）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)