### PR TITLE
fix: anchor the read-only view's edit hint over the diagram

### DIFF
--- a/src/preview/DrawioPreviewFileView.ts
+++ b/src/preview/DrawioPreviewFileView.ts
@@ -53,7 +53,12 @@ export class DrawioPreviewFileView extends TextFileView {
       });
     }
 
-    const preview = c.createDiv({ cls: 'drawio-preview' });
+    // The hint's absolute centring must resolve against the diagram, not the
+    // tab-filling contentEl (there it floats mid-tab in empty space) — and it
+    // can't live inside .drawio-preview, which renderPreview() empties on
+    // every (re-)render, so a page flip would silently drop it.
+    const previewWrap = c.createDiv({ cls: 'drawio-preview-wrap' });
+    const preview = previewWrap.createDiv({ cls: 'drawio-preview' });
     const pages = getDiagramPages(ensureMxfile(this.data));
     renderPreview(preview, this.data, { ...this.plugin.previewOpts(), page: 0 });
 
@@ -69,7 +74,7 @@ export class DrawioPreviewFileView extends TextFileView {
     }
 
     if (Platform.isDesktopApp && action.hint) {
-      addEditHint(c, action.hint.label, action.hint.icon);
+      addEditHint(previewWrap, action.hint.label, action.hint.icon);
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,9 @@
 
 /* ---- Read-only file view (.drawio files: always on mobile, opt-in on desktop) ---- */
 .drawio-preview-file-view { position: relative; height: 100%; overflow: auto; padding: 12px; }
+/* Positioning context for the hover "Edit" hint: anchors it over the diagram
+   itself instead of the tab-filling view container. */
+.drawio-preview-file-view .drawio-preview-wrap { position: relative; }
 .drawio-preview-file-view.drawio-clickable { cursor: pointer; }
 .drawio-preview-file-view:hover .drawio-edit-hint,
 .drawio-preview-file-view:focus-within .drawio-edit-hint { opacity: .92; }

--- a/tests/drawioPreviewFileView.test.ts
+++ b/tests/drawioPreviewFileView.test.ts
@@ -109,6 +109,24 @@ describe('DrawioPreviewFileView', () => {
     expect(view.contentEl.querySelector('.drawio-page-control')).not.toBeNull();
   });
 
+  it('anchors the edit hint to the preview wrapper, not the tab-filling container', () => {
+    Platform.isDesktopApp = true;
+    const view = makeView(fakePlugin());
+    view.setViewData(XML, true);
+    const hint = view.contentEl.querySelector('.drawio-edit-hint');
+    expect(hint?.parentElement?.classList.contains('drawio-preview-wrap')).toBe(true);
+  });
+
+  it('keeps the edit hint after flipping pages (renderPreview empties only .drawio-preview)', () => {
+    Platform.isDesktopApp = true;
+    const view = makeView(fakePlugin());
+    view.setViewData(MULTI_PAGE_XML, true);
+    const nextBtn = view.contentEl.querySelectorAll<HTMLButtonElement>('.drawio-page-control button')[1];
+    expect(nextBtn?.textContent).toBe('›');
+    nextBtn?.click();
+    expect(view.contentEl.querySelector('.drawio-edit-hint')).not.toBeNull();
+  });
+
   it('getViewData returns the last data set (no write path)', () => {
     Platform.isDesktopApp = false;
     const view = makeView(fakePlugin());


### PR DESCRIPTION
## 问题

只读文件视图（`readonlyFileView`）中，悬停显示的「Edit」提示按钮出现在整个标签页的正中央空白处，远离图形本身。

## 原因

`.drawio-edit-hint` 通过 `position: absolute; inset: 0; margin: auto` 在最近的定位祖先内居中。代码块与嵌入预览的定位祖先是随内容大小的预览容器，按钮正好悬浮在图上；而 `DrawioPreviewFileView` 把提示挂在占满标签页的 `contentEl`（`position: relative`）上，于是按钮居中于整个标签页。

## 改动

- 预览外包一层 `position: relative` 的 `.drawio-preview-wrap`，提示挂载其上——行为与代码块、嵌入一致（悬浮于图形中央）。
- 不能直接挂进 `.drawio-preview`：`renderPreview()` 每次渲染都会清空目标容器，翻页会把提示一并清掉。
- 新增两条回归测试：提示锚定于包裹层；多页图翻页后提示仍在。

## 测试

受影响测试文件 11 项全部通过；全套测试与 `npm run build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)