### PR TITLE
feat: offline editor install detection + one-click installer (no more silent online fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ These are separate; a change to one rarely affects the other.
 
 - `src/main.ts` — plugin entry: settings, local server, registers the code-block
   processor / file view / embeds / `Create new diagram` command / settings tab.
-  `resolveBaseUrl()` picks the editor URL (offline → local server, with **automatic
-  online fallback** when the webapp isn't installed).
+  `resolveBaseUrl()` picks the editor URL (offline → local server; throws a typed
+  `OfflineEditorNotInstalledError` when the webapp isn't installed — the automatic
+  online fallback was removed after 0.4.x, **no automatic fallback** anymore).
 - `src/constants.ts` — view type, file ext, `ONLINE_DRAWIO_URL`, `EMPTY_DIAGRAM`, `buildEmbedQuery`.
 - `src/settings.ts` / `src/settingsTab.ts` — settings model + settings tab.
 - `src/model/` — `DrawioSource` (edit-target abstraction: code block or file),
@@ -98,7 +99,9 @@ name; the manifest id inside is `drawio-editor`).
     which rejects with `TypeError: Failed to fetch dynamically imported
     module`. In 0.4.0 that broke **every desktop editor mount in offline mode**
     (`resolveBaseUrl()` threw before its webapp check, so not even the online
-    fallback ran). Fixed in 0.4.1 by `supported: { 'dynamic-import': false }`
+    fallback ran — that fallback has since been removed, see "Default editor
+    mode" below; at the time this bug was found it still existed). Fixed in
+    0.4.1 by `supported: { 'dynamic-import': false }`
     in `esbuild.config.mjs`, which lowers every dynamic import to a lazy
     promise-wrapped `require()` (still evaluated at the call site, so the
     mobile rule above holds), plus `guardNativeNodeImportsPlugin`, which fails
@@ -154,9 +157,25 @@ name; the manifest id inside is `drawio-editor`).
     good value) since `display()` has no built-in `validate` callback.
 - **`onunload()` must NOT `detachLeavesOfType`.** Detaching resets the user's view to
   its default location on next load. Only stop the server.
-- **Default editor mode is `offline`** with automatic online fallback. The ~145 MB
-  `webapp/` can't ship via the store, so store installs have no webapp and
-  `resolveBaseUrl()` falls back to `ONLINE_DRAWIO_URL` (one-time Notice, not a throw).
+- **Default editor mode is `offline`, with NO automatic online fallback** (the
+  fallback existed through 0.4.x and was removed on purpose — don't reintroduce
+  it). The ~145 MB `webapp/` can't ship via the store, so store installs start
+  without it: `resolveBaseUrl()` throws `OfflineEditorNotInstalledError`
+  (`src/model/errors.ts`), whose message both editor entry points surface, and
+  the settings tab offers a one-click installer
+  (`src/desktop/webappInstaller.ts`: `node:https` download of the pinned
+  `draw.war` → `fflate` extract to a `webapp.installing/` staging dir →
+  validate `index.html`/`js/viewer.min.js` exist → rename-aside swap into
+  `webapp/` — the existing `webapp/` is renamed to `webapp.old/` first, the
+  staging dir is renamed into `webapp/`, and on failure `webapp.old/` is
+  renamed straight back so an install never leaves the vault with no webapp at
+  all; a successful install best-effort-removes the `webapp.old/` leftover;
+  the caller stops the local server first for Windows file locks). `fflate` is
+  a devDependency inlined by esbuild. The pinned version lives in
+  `src/constants.ts` (`DRAWIO_VERSION`) and a test asserts it matches
+  `scripts/fetch-drawio.mjs`. A load-time notice
+  (`registerDesktopFeatures.ts`) points offline-mode users at settings when
+  the webapp is missing.
 - **Popout-window safety**: use `activeDocument`/`activeWindow` (baseline-supported),
   not `document`/`window`, in render paths.
 - **A popped-out `.drawio` editor needs BOTH directions of the `postMessage` bridge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,11 @@ name; the manifest id inside is `drawio-editor`).
   `require(...)` call — which throws immediately on mobile (no Node runtime),
   crashing the *entire plugin load* before `onload()` even runs. Fixed by
   never letting a `node:*`/`electron` import be *static and top-level* outside
-  `src/server/**` or `src/desktop/**` — both are only ever reached through the
-  one `Platform.isDesktopApp`-gated dynamic import in `main.ts`'s
-  `maybeRegisterDesktopFeatures()`. A dynamic `await import(...)` at the point
+  `src/server/**` or `src/desktop/**` — both are only ever reached through
+  `Platform.isDesktopApp`-gated dynamic imports: `main.ts`'s
+  `maybeRegisterDesktopFeatures()`, and `settingsTab.ts`'s `startInstall()`
+  (whose offline-editor row only renders inside the tab's desktop-gated
+  block). A dynamic `await import(...)` at the point
   of use (e.g. `main.ts`'s `pluginDir()`/`resolveBaseUrl()`) is fine anywhere,
   since it's never eagerly evaluated — only a *static* top-level import gets
   hoisted and unconditionally `require()`d. **If you add a new Node/Electron

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,10 @@ name; the manifest id inside is `drawio-editor`).
   staging dir is renamed into `webapp/`, and on failure `webapp.old/` is
   renamed straight back so an install never leaves the vault with no webapp at
   all; a successful install best-effort-removes the `webapp.old/` leftover;
-  the caller stops the local server first for Windows file locks). `fflate` is
+  the caller stops the local server first for Windows file locks; when the
+  installed webapp's `DRAWIO_VERSION` file differs from the pinned constant,
+  the row shows an **Update** button — same pipeline, always installs the
+  pin, keeping the webapp in lockstep with the bundled viewer). `fflate` is
   a devDependency inlined by esbuild. The pinned version lives in
   `src/constants.ts` (`DRAWIO_VERSION`) and a test asserts it matches
   `scripts/fetch-drawio.mjs`. A load-time notice

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ On mobile, only **Preview alignment** and **Follow Obsidian theme** are shown �
 
 ## Offline editor (optional)
 
-A store install ships without the offline drawio webapp (it is ~145 MB, beyond store limits). To install it, open **Settings → Drawio**, select **Editor source → Offline (bundled webapp)**, and click **Install** — a one-time ~53 MB download from GitHub; editing is fully offline afterwards.
+A store install ships without the offline drawio webapp (it is ~145 MB, beyond store limits). To install it, open **Settings → Drawio**, select **Editor source → Offline (bundled webapp)**, and click **Install** — a one-time ~53 MB download from GitHub; editing is fully offline afterwards. After a plugin update that bumps the bundled drawio version, the same row shows **Update** until the installed webapp matches again.
 
 Building from source also works and produces the same layout: run `npm run fetch-drawio` before `npm run build` and copy the `webapp/` folder alongside `main.js` (see Development below).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Embed, preview, and edit [draw.io](https://www.drawio.com/) (diagrams.net) diagr
 
 - **Three surfaces, one plugin** — inline `` ```drawio `` code blocks, standalone `.drawio` files (Excalidraw-style: the editor lives right in the file's tab), and `![[file.drawio]]` embeds. All three render live SVG previews in both editing and reading views; click any preview to edit.
 - **Offline previews, always** — previews are produced by drawio's own viewer bundled into the plugin: no iframe, no network, on desktop and mobile alike.
-- **Offline editor, optionally** — the editor defaults to a bundled, fully offline drawio build served from a local server. When that bundle isn't installed (store installs), it automatically falls back to the online diagrams.net editor — so it works out of the box either way.
+- **Offline editor, optionally** — the editor defaults to a bundled, fully offline drawio build served from a local server. Store installs don't include the bundle (~145 MB); install it with one click from the plugin settings, or switch the editor source to Online.
 - **Readable, git-friendly storage** — diagrams are saved as uncompressed, pretty-printed XML rather than a compressed blob, so diffs, sync, and version history stay meaningful.
 - **Multi-page aware** — multi-page diagrams get a compact page switcher (‹ 2 / 5 ›) under the preview, and `![[file.drawio#Page-2]]` opens the embed on the page named "Page-2".
 - **Fits into Obsidian** — follows your light/dark theme, keeps working in popped-out windows, sanitizes rendered SVG before insertion, and supports phones and tablets (preview-only there — see [Platform support](#platform-support)).
@@ -23,7 +23,7 @@ Embed, preview, and edit [draw.io](https://www.drawio.com/) (diagrams.net) diagr
 2. Click the **ribbon button**, run the **Create new diagram** command, or right-click a folder in the file explorer and choose **New drawio diagram**.
 3. A new `.drawio` file opens with the editor embedded in its tab. Draw — changes autosave back to the file.
 
-No extra setup is needed: a store install uses the online diagrams.net editor automatically. To make editing fully offline as well, see [Offline editor](#offline-editor-optional).
+The editor needs one of: the offline editor installed (one click in settings, ~53 MB download), or **Editor source → Online** in the plugin settings. See [Offline editor](#offline-editor-optional).
 
 ## Usage
 
@@ -59,7 +59,7 @@ Phones and tablets behave identically: previews everywhere, no editing. Tapping 
 
 | Setting | Description |
 | --- | --- |
-| **Editor source** | **Offline** (bundled webapp, default), **Online** (diagrams.net), or a **Custom URL**. Offline falls back to Online automatically when the bundled webapp isn't installed. |
+| **Editor source** | **Offline** (bundled webapp, default), **Online** (diagrams.net), or a **Custom URL**. Offline requires the one-time install below — there is no automatic fallback. |
 | **Custom drawio URL** | Used when Editor source is "Custom URL" (e.g. `https://embed.diagrams.net/`). |
 | **New diagram location** | Where the command and ribbon button create diagrams: vault root (default), the current note's folder, or a fixed folder (created if missing). The folder context menu always creates in the clicked folder. |
 | **Open diagram files read-only** | Desktop: show a static preview instead of the embedded editor when opening `.drawio` files — for workflows centred on drawio-desktop. Applies to newly opened tabs. |
@@ -75,17 +75,13 @@ On mobile, only **Preview alignment** and **Follow Obsidian theme** are shown �
 
 - **Previews never use the network.** They are rendered by drawio's `viewer.min.js`, which is bundled into the plugin.
 - **With the bundled offline editor**, the plugin makes **no network requests at all** — the editor is served from a local `127.0.0.1` HTTP server.
-- **When the bundle isn't installed** (the store-install default), the editor UI is loaded from `https://embed.diagrams.net/`. Your diagram content still stays on your device — it is passed to the editor in the page and is **not uploaded**; only the editor's assets are fetched. You can also explicitly choose Online or a Custom URL in settings.
+- **When the bundle isn't installed**, Offline mode shows an install prompt instead of silently going online. If you choose **Online** (or a Custom URL), the editor UI is loaded from that origin. Your diagram content still stays on your device — it is passed to the editor in the page and is **not uploaded**; only the editor's assets are fetched.
 
 ## Offline editor (optional)
 
-A store install ships without the offline drawio webapp (it is ~145 MB, beyond store limits). To make editing fully offline, build from source:
+A store install ships without the offline drawio webapp (it is ~145 MB, beyond store limits). To install it, open **Settings → Drawio**, select **Editor source → Offline (bundled webapp)**, and click **Install** — a one-time ~53 MB download from GitHub; editing is fully offline afterwards.
 
-1. `git clone https://github.com/doge-liang/obsidian-drawio && cd obsidian-drawio && npm install`
-2. `npm run fetch-drawio` — downloads the pinned drawio webapp (~40 MB download, ~145 MB extracted; needs network access to GitHub plus `unzip` or `python3`).
-3. `npm run build`
-4. Copy `main.js`, `manifest.json`, `styles.css`, and the `webapp/` folder into `<vault>/.obsidian/plugins/drawio-editor/`.
-5. Enable **Drawio**, then set **Editor source → Offline (bundled webapp)** in the plugin settings.
+Building from source also works and produces the same layout: run `npm run fetch-drawio` before `npm run build` and copy the `webapp/` folder alongside `main.js` (see Development below).
 
 ## Notes & limitations
 

--- a/docs/superpowers/plans/2026-07-11-offline-webapp-install.md
+++ b/docs/superpowers/plans/2026-07-11-offline-webapp-install.md
@@ -1,0 +1,1175 @@
+# Offline Webapp Detection & One-Click Install Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the silent offline→online fallback; add webapp install detection plus a one-click installer (download + extract) in the settings tab.
+
+**Architecture:** A typed error (`src/model/errors.ts`) replaces the fallback in `resolveBaseUrl()`; both editor entry points already catch mount errors and will surface its message. A desktop-only installer module (`src/desktop/webappInstaller.ts`, static node imports allowed there) downloads the pinned `draw.war` via `node:https` into memory, extracts with `fflate` into `webapp.installing/`, validates, then atomically renames to `webapp/`. Install state lives on the plugin instance (`InstallStatus`) so settings re-renders never lose progress. Spec: `docs/superpowers/specs/2026-07-11-offline-webapp-install-design.md`.
+
+**Tech Stack:** TypeScript, Obsidian plugin API, esbuild (bundles `fflate` inline), vitest + jsdom, `node:https`/`node:fs` (desktop only).
+
+## Global Constraints
+
+- Node/electron imports: static top-level imports of `node:*` ONLY inside `src/server/**` or `src/desktop/**`; everywhere else use dynamic `await import('node:...')` inside the function body. Never remove `supported: { 'dynamic-import': false }` from `esbuild.config.mjs`.
+- No `createElement('script')`, no DOMPurify, no regex-literal lookbehind/named-groups/`\p{}` anywhere in `src/`.
+- No new Obsidian APIs newer than `minAppVersion` `1.4.0` (this plan uses only `Notice`, `Setting.addButton`/`setDesc`, `ButtonComponent` — all long-baseline).
+- `fflate` goes in **devDependencies** (esbuild inlines it into `main.js`; Obsidian never runs npm install).
+- UI copy: English, sentence case (Obsidian convention).
+- drawio version stays pinned at `v30.0.4` and must match `scripts/fetch-drawio.mjs`.
+- `window.setTimeout`/`window.clearTimeout` (not bare globals) if timers are ever added; none planned.
+- Each task: run `npx tsc -noEmit -skipLibCheck` and `npm test` before committing.
+
+---
+
+### Task 1: Dependencies + pinned version constants
+
+**Files:**
+- Modify: `package.json` (add `fflate` devDependency)
+- Modify: `src/constants.ts` (add `DRAWIO_VERSION`, `DRAWIO_WAR_URL`)
+- Test: `tests/drawioVersionSync.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `DRAWIO_VERSION: string` (`'v30.0.4'`) and `DRAWIO_WAR_URL: string`, exported from `src/constants.ts`. Task 3 imports both.
+
+- [ ] **Step 1: Install dependencies in the worktree**
+
+The worktree is fresh (no `node_modules/`, no `webapp/`, no `src/preview/viewer.min.txt` — the viewer-dependent test suites skip themselves when the file is absent; that is expected until Task 6).
+
+```bash
+npm install
+npm install --save-dev fflate
+```
+
+Expected: `fflate` appears in `package.json` devDependencies; `package-lock.json` updated.
+
+- [ ] **Step 2: Write the failing version-sync test**
+
+Create `tests/drawioVersionSync.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { DRAWIO_VERSION, DRAWIO_WAR_URL } from '../src/constants';
+
+// The runtime installer (src/desktop/webappInstaller.ts) and the build-time
+// fetch script must install the exact same drawio version, or the bundled
+// viewer.min.txt and the installed webapp drift apart.
+describe('drawio version pinning', () => {
+  it('matches the version pinned in scripts/fetch-drawio.mjs', () => {
+    const script = readFileSync('scripts/fetch-drawio.mjs', 'utf8');
+    const m = script.match(/DRAWIO_VERSION = '([^']+)'/);
+    expect(m?.[1]).toBe(DRAWIO_VERSION);
+  });
+
+  it('builds the war URL from the pinned version', () => {
+    expect(DRAWIO_WAR_URL).toBe(
+      `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`,
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/drawioVersionSync.test.ts`
+Expected: FAIL — `'"DRAWIO_VERSION" is not exported'` (or similar import error).
+
+- [ ] **Step 4: Add the constants**
+
+In `src/constants.ts`, after the `ONLINE_DRAWIO_URL` export:
+
+```ts
+/** Pinned drawio version — MUST match scripts/fetch-drawio.mjs (guarded by
+ * tests/drawioVersionSync.test.ts) so the runtime-installed webapp matches the
+ * bundled viewer.min.txt. */
+export const DRAWIO_VERSION = 'v30.0.4';
+
+/** The pinned drawio webapp archive (a ZIP), downloaded by the settings-tab
+ * one-click installer. */
+export const DRAWIO_WAR_URL =
+  `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/drawioVersionSync.test.ts && npx tsc -noEmit -skipLibCheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json src/constants.ts tests/drawioVersionSync.test.ts
+git commit -m "feat: pin drawio version/war URL in constants, add fflate dep"
+```
+
+---
+
+### Task 2: Typed error + detection + remove the offline→online fallback
+
+**Files:**
+- Create: `src/model/errors.ts`
+- Modify: `src/main.ts:1` (imports), `src/main.ts:13-14` (remove field), `src/main.ts:77-104` (`resolveBaseUrl`), add `isWebappInstalled()`/`installedWebappVersion()` after `pluginDir()` (line 75)
+- Modify: `src/editor/DrawioModal.ts:24-28`
+- Modify: `src/file/DrawioFileView.ts:66-69`
+- Test: `tests/resolveBaseUrl.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces:
+  - `class OfflineEditorNotInstalledError extends Error` in `src/model/errors.ts` (constructor takes no arguments; `message` is user-facing copy).
+  - `DrawioPlugin.isWebappInstalled(): Promise<boolean>` — Task 4 (load-time notice) and Task 5 (settings row) call it.
+  - `DrawioPlugin.installedWebappVersion(): Promise<string | null>` — Task 5 calls it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/resolveBaseUrl.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import DrawioPlugin from '../src/main';
+import { OfflineEditorNotInstalledError } from '../src/model/errors';
+import { ONLINE_DRAWIO_URL } from '../src/constants';
+
+// resolveBaseUrl/isWebappInstalled are instance methods with no constructor
+// dependencies beyond the fields they read, so they are tested via
+// prototype.call on a minimal fake (same pattern as other suites' fakePlugin).
+// The cast keeps strictBindCallApply satisfied.
+const proto = DrawioPlugin.prototype;
+const asPlugin = (o: object) => o as unknown as DrawioPlugin;
+
+describe('resolveBaseUrl', () => {
+  it('throws OfflineEditorNotInstalledError in offline mode without the webapp', async () => {
+    const fake = asPlugin({
+      settings: { drawioMode: 'offline', customDrawioUrl: '' },
+      isWebappInstalled: async () => false,
+    });
+    await expect(proto.resolveBaseUrl.call(fake)).rejects.toBeInstanceOf(
+      OfflineEditorNotInstalledError,
+    );
+  });
+
+  it('serves from the local server in offline mode when installed', async () => {
+    const touch = vi.fn();
+    const fake = asPlugin({
+      settings: { drawioMode: 'offline', customDrawioUrl: '' },
+      isWebappInstalled: async () => true,
+      server: { ensureStarted: async () => 3456, touch },
+    });
+    await expect(proto.resolveBaseUrl.call(fake)).resolves.toBe(
+      'http://127.0.0.1:3456/index.html',
+    );
+    expect(touch).toHaveBeenCalled();
+  });
+
+  it('returns the online URL in online mode', async () => {
+    const fake = asPlugin({ settings: { drawioMode: 'online', customDrawioUrl: '' } });
+    await expect(proto.resolveBaseUrl.call(fake)).resolves.toBe(ONLINE_DRAWIO_URL);
+  });
+});
+
+describe('isWebappInstalled / installedWebappVersion', () => {
+  it('reflects webapp/index.html presence and reads DRAWIO_VERSION', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'drawio-detect-'));
+    try {
+      const fake = asPlugin({ pluginDir: async () => dir });
+      expect(await proto.isWebappInstalled.call(fake)).toBe(false);
+      expect(await proto.installedWebappVersion.call(fake)).toBeNull();
+
+      mkdirSync(join(dir, 'webapp'), { recursive: true });
+      writeFileSync(join(dir, 'webapp', 'index.html'), '<html></html>');
+      expect(await proto.isWebappInstalled.call(fake)).toBe(true);
+      // Manually-installed webapps may lack the version file — that is not an error.
+      expect(await proto.installedWebappVersion.call(fake)).toBeNull();
+
+      writeFileSync(join(dir, 'webapp', 'DRAWIO_VERSION'), 'v30.0.4\n');
+      expect(await proto.installedWebappVersion.call(fake)).toBe('v30.0.4');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/resolveBaseUrl.test.ts`
+Expected: FAIL — cannot resolve `../src/model/errors`.
+
+- [ ] **Step 3: Create the error class**
+
+Create `src/model/errors.ts` (pure TS, no node imports — safe to import from any module on any platform):
+
+```ts
+/** Thrown by resolveBaseUrl() when the editor source is Offline but the bundled
+ * webapp isn't installed. The message is user-facing: both editor entry points
+ * (DrawioModal, DrawioFileView) display it verbatim. There is deliberately no
+ * automatic online fallback — offline means offline. */
+export class OfflineEditorNotInstalledError extends Error {
+  constructor() {
+    super(
+      "The offline drawio editor isn't installed. Install it in the Drawio plugin " +
+      'settings, or switch the editor source to Online.',
+    );
+    this.name = 'OfflineEditorNotInstalledError';
+  }
+}
+```
+
+- [ ] **Step 4: Rework `src/main.ts`**
+
+Replace the import line 1 (drop `Notice`, add the error import below it):
+
+```ts
+import { Plugin, FileSystemAdapter, Platform } from 'obsidian';
+import { OfflineEditorNotInstalledError } from './model/errors';
+```
+
+Delete the field on lines 13-14:
+
+```ts
+  /** Show the "offline editor missing, using online" notice only once. */
+  private warnedOfflineFallback = false;
+```
+
+Add the two detection methods right after `pluginDir()` (after line 75):
+
+```ts
+  /** Whether the bundled offline webapp is installed (same criterion the local
+   * server relies on: webapp/index.html exists). Desktop-only caller; node
+   * modules are imported dynamically per the mobile-safety rule. */
+  async isWebappInstalled(): Promise<boolean> {
+    const path = await import('node:path');
+    const fs = await import('node:fs');
+    return fs.existsSync(path.join(await this.pluginDir(), 'webapp', 'index.html'));
+  }
+
+  /** The installed webapp's pinned version (from the DRAWIO_VERSION file the
+   * installer/fetch script writes), or null when absent — manual installs may
+   * not carry the file, which is fine. Desktop-only caller. */
+  async installedWebappVersion(): Promise<string | null> {
+    try {
+      const path = await import('node:path');
+      const fs = await import('node:fs');
+      const raw = fs.readFileSync(
+        path.join(await this.pluginDir(), 'webapp', 'DRAWIO_VERSION'), 'utf8');
+      return raw.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+```
+
+Replace the offline branch of `resolveBaseUrl()` (lines 82-101) so the whole method reads:
+
+```ts
+  async resolveBaseUrl(): Promise<string> {
+    const mode = this.settings.drawioMode;
+    if (mode === 'custom' && this.settings.customDrawioUrl) {
+      return this.settings.customDrawioUrl;
+    }
+    if (mode === 'offline') {
+      // No fallback: offline means offline. The entry points surface this
+      // error's message, which points at the settings-tab installer.
+      if (!(await this.isWebappInstalled())) {
+        throw new OfflineEditorNotInstalledError();
+      }
+      const port = await this.server!.ensureStarted();
+      this.server!.touch();
+      return `http://127.0.0.1:${port}/index.html`;
+    }
+    // 'online' (and 'custom' with no URL set) → the hosted diagrams.net embed.
+    return ONLINE_DRAWIO_URL;
+  }
+```
+
+- [ ] **Step 5: Surface the message at both entry points**
+
+`src/editor/DrawioModal.ts` — add the import and replace the catch block (lines 24-28):
+
+```ts
+import { OfflineEditorNotInstalledError } from '../model/errors';
+```
+
+```ts
+    } catch (err) {
+      console.error('[drawio] failed to open editor:', err);
+      const msg = err instanceof OfflineEditorNotInstalledError
+        ? err.message
+        : 'Drawio: failed to open editor — see console (Ctrl+Shift+I)';
+      new Notice(msg, 8000);
+      this.contentEl.createDiv({
+        cls: 'drawio-error',
+        text: err instanceof Error ? err.message : String(err),
+      });
+    }
+```
+
+`src/file/DrawioFileView.ts` — replace the mount catch (lines 66-69):
+
+```ts
+    this.editor.mount().catch((err) => {
+      console.error('[drawio] file-view editor failed to mount', err);
+      c.createDiv({
+        cls: 'drawio-error',
+        text: err instanceof Error ? err.message : String(err),
+      });
+    });
+```
+
+- [ ] **Step 6: Run the suite**
+
+Run: `npx vitest run && npx tsc -noEmit -skipLibCheck`
+Expected: all tests PASS (viewer-dependent suites skip — expected in this worktree), no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/model/errors.ts src/main.ts src/editor/DrawioModal.ts src/file/DrawioFileView.ts tests/resolveBaseUrl.test.ts
+git commit -m "feat!: remove offline->online fallback; typed not-installed error"
+```
+
+---
+
+### Task 3: Installer library (`webappInstaller.ts`) + real-download feasibility check
+
+**Files:**
+- Create: `src/desktop/webappInstaller.ts`
+- Create: `src/model/installStatus.ts` (progress/state types only in this task; class consumed in Task 5)
+- Test: `tests/webappInstaller.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `DRAWIO_VERSION`, `DRAWIO_WAR_URL` from `src/constants.ts` (Task 1).
+- Produces:
+  - `type InstallProgress = { phase: 'download'; received: number; total: number | null } | { phase: 'extract' }` (in `src/model/installStatus.ts`).
+  - `installWebapp(pluginDir: string, onProgress: (p: InstallProgress) => void): Promise<void>` (in `src/desktop/webappInstaller.ts`) — Task 5's settings button calls it via dynamic import.
+  - `installFromWar(war: Uint8Array, pluginDir: string): void` (exported for tests; the post-download half).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/webappInstaller.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { zipSync, strToU8 } from 'fflate';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { installFromWar } from '../src/desktop/webappInstaller';
+import { DRAWIO_VERSION } from '../src/constants';
+
+function makeWar(entries: Record<string, Uint8Array> = {}): Uint8Array {
+  return zipSync({
+    'index.html': strToU8('<html>drawio</html>'),
+    'js/viewer.min.js': strToU8('// viewer'),
+    'WEB-INF/web.xml': strToU8('<web-app/>'),
+    'META-INF/MANIFEST.MF': strToU8('Manifest-Version: 1.0'),
+    ...entries,
+  });
+}
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'drawio-install-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('installFromWar', () => {
+  it('extracts the webapp, skipping WEB-INF/META-INF, and writes DRAWIO_VERSION', () => {
+    installFromWar(makeWar(), dir);
+    expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('<html>drawio</html>');
+    expect(existsSync(join(dir, 'webapp', 'js', 'viewer.min.js'))).toBe(true);
+    expect(existsSync(join(dir, 'webapp', 'WEB-INF'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp', 'META-INF'))).toBe(false);
+    expect(readFileSync(join(dir, 'webapp', 'DRAWIO_VERSION'), 'utf8').trim()).toBe(DRAWIO_VERSION);
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+
+  it('replaces an existing webapp atomically', () => {
+    mkdirSync(join(dir, 'webapp'), { recursive: true });
+    writeFileSync(join(dir, 'webapp', 'stale.txt'), 'old');
+    installFromWar(makeWar(), dir);
+    expect(existsSync(join(dir, 'webapp', 'stale.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
+  });
+
+  it('cleans leftover webapp.installing from a previously interrupted run', () => {
+    mkdirSync(join(dir, 'webapp.installing'), { recursive: true });
+    writeFileSync(join(dir, 'webapp.installing', 'junk.txt'), 'junk');
+    installFromWar(makeWar(), dir);
+    expect(existsSync(join(dir, 'webapp', 'junk.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
+  });
+
+  it('rejects an archive missing required files, keeping the old webapp intact', () => {
+    mkdirSync(join(dir, 'webapp'), { recursive: true });
+    writeFileSync(join(dir, 'webapp', 'index.html'), 'previous install');
+    const bad = zipSync({ 'js/viewer.min.js': strToU8('// viewer only') });
+    expect(() => installFromWar(bad, dir)).toThrow(/index\.html/);
+    // Old install untouched, staging cleaned up.
+    expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('previous install');
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+
+  it('rejects zip entries that escape the target directory (zip-slip)', () => {
+    // If fflate's zipSync ever refuses to create '../' entry names, keep the
+    // guard in the implementation and adapt this test to call the exported
+    // path check directly instead of deleting the test.
+    const evil = makeWar({ '../evil.txt': strToU8('escape') });
+    expect(() => installFromWar(evil, dir)).toThrow(/[Uu]nsafe zip entry/);
+    expect(existsSync(join(dir, 'evil.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/webappInstaller.test.ts`
+Expected: FAIL — cannot resolve `../src/desktop/webappInstaller`.
+
+- [ ] **Step 3: Create the progress type module**
+
+Create `src/model/installStatus.ts` (pure TS — no node imports; Task 5 extends this file with the `InstallStatus` class):
+
+```ts
+/** Progress events emitted by the offline-webapp installer. Download progress
+ * is per-chunk; extraction is a single coarse phase (fflate's unzipSync is
+ * synchronous — deliberately no finer granularity, per the design spec). */
+export type InstallProgress =
+  | { phase: 'download'; received: number; total: number | null }
+  | { phase: 'extract' };
+```
+
+- [ ] **Step 4: Implement the installer**
+
+Create `src/desktop/webappInstaller.ts`. This file lives in `src/desktop/**`, so static `node:*` imports are allowed (it is only ever loaded through desktop-gated dynamic imports).
+
+```ts
+import { get } from 'node:https';
+import {
+  existsSync, mkdirSync, renameSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { dirname, join, normalize, sep } from 'node:path';
+import { unzipSync } from 'fflate';
+import { DRAWIO_VERSION, DRAWIO_WAR_URL } from '../constants';
+import type { InstallProgress } from '../model/installStatus';
+
+/** Top-level directories in draw.war that are server-only and never served
+ * (same exclusions as scripts/fetch-drawio.mjs). */
+const SKIP_PREFIXES = ['WEB-INF/', 'META-INF/'];
+
+/**
+ * Download the pinned drawio webapp and install it into `<pluginDir>/webapp`.
+ * The caller (settings tab) must stop the local server first — on Windows an
+ * open file handle inside webapp/ would make the final swap fail.
+ *
+ * The whole archive (~53 MB) is buffered in memory: it spares a temp file and
+ * its cleanup, and is well within desktop Electron's budget.
+ */
+export async function installWebapp(
+  pluginDir: string,
+  onProgress: (p: InstallProgress) => void,
+): Promise<void> {
+  const war = await download(DRAWIO_WAR_URL, onProgress);
+  onProgress({ phase: 'extract' });
+  installFromWar(war, pluginDir);
+}
+
+/** The post-download half, separated for network-free testing: extract into a
+ * staging dir, validate, then atomically swap into place. On any failure the
+ * staging dir is removed and an existing webapp/ is left untouched. */
+export function installFromWar(war: Uint8Array, pluginDir: string): void {
+  const staging = join(pluginDir, 'webapp.installing');
+  rmSync(staging, { recursive: true, force: true });
+  try {
+    extract(war, staging);
+    for (const f of ['index.html', join('js', 'viewer.min.js')]) {
+      if (!existsSync(join(staging, f))) {
+        throw new Error(`The downloaded webapp is missing ${f} — aborting install.`);
+      }
+    }
+    writeFileSync(join(staging, 'DRAWIO_VERSION'), DRAWIO_VERSION + '\n');
+    const dest = join(pluginDir, 'webapp');
+    rmSync(dest, { recursive: true, force: true });
+    renameSync(staging, dest);
+  } catch (e) {
+    rmSync(staging, { recursive: true, force: true });
+    throw e;
+  }
+}
+
+function extract(war: Uint8Array, destDir: string): void {
+  const entries = unzipSync(war, {
+    filter: (f) => !SKIP_PREFIXES.some((p) => f.name.startsWith(p)),
+  });
+  for (const [name, data] of Object.entries(entries)) {
+    if (name.endsWith('/')) continue; // directory entry
+    const target = normalize(join(destDir, name));
+    // Zip-slip guard: the source is a pinned HTTPS URL, but entry names are
+    // still attacker-shaped input in principle — never write outside destDir.
+    if (!target.startsWith(destDir + sep)) {
+      throw new Error(`Unsafe zip entry path: ${name}`);
+    }
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, data);
+  }
+}
+
+/** GET with redirect following (GitHub release assets 302 to object storage).
+ * node:https rather than fetch/requestUrl: streams progress and needs no CORS. */
+function download(
+  url: string,
+  onProgress: (p: InstallProgress) => void,
+  redirects = 0,
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    if (redirects > 5) {
+      reject(new Error(`Too many redirects downloading ${url}`));
+      return;
+    }
+    const req = get(url, (res) => {
+      const status = res.statusCode ?? 0;
+      const location = res.headers.location;
+      if (status >= 300 && status < 400 && location) {
+        res.resume();
+        resolve(download(new URL(location, url).toString(), onProgress, redirects + 1));
+        return;
+      }
+      if (status !== 200) {
+        res.resume();
+        reject(new Error(`Download failed: HTTP ${status} for ${url}`));
+        return;
+      }
+      const lenHeader = res.headers['content-length'];
+      const total = lenHeader ? Number(lenHeader) : null;
+      const chunks: Buffer[] = [];
+      let received = 0;
+      res.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+        received += chunk.length;
+        onProgress({ phase: 'download', received, total });
+      });
+      res.on('end', () => {
+        if (total !== null && received !== total) {
+          reject(new Error(`Download incomplete: got ${received} of ${total} bytes`));
+          return;
+        }
+        resolve(Buffer.concat(chunks));
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+  });
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/webappInstaller.test.ts && npx tsc -noEmit -skipLibCheck`
+Expected: PASS. If the zip-slip test fails because `zipSync` normalizes the entry name, follow the note inside that test.
+
+- [ ] **Step 6: Feasibility check — real download through the production code**
+
+This validates the riskiest assumptions (redirect handling, content-length check, fflate on the real 53 MB war) before any UI is built, per the design spec. Not committed; uses a throwaway temp dir.
+
+```bash
+TMP=$(mktemp -d)
+npx esbuild src/desktop/webappInstaller.ts --bundle --platform=node --format=esm --outfile="$TMP/installer.mjs"
+cat > "$TMP/drive.mjs" <<'EOF'
+import { installWebapp } from './installer.mjs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const dir = mkdtempSync(join(tmpdir(), 'drawio-feas-'));
+let lastPct = -1;
+await installWebapp(dir, (p) => {
+  if (p.phase === 'extract') { console.log('extracting…'); return; }
+  if (p.total) {
+    const pct = Math.floor((p.received / p.total) * 100);
+    if (pct !== lastPct && pct % 20 === 0) { lastPct = pct; console.log(`download ${pct}%`); }
+  }
+});
+for (const f of ['index.html', join('js', 'viewer.min.js'), 'DRAWIO_VERSION']) {
+  if (!existsSync(join(dir, 'webapp', f))) throw new Error(`missing webapp/${f}`);
+}
+console.log('installed version:', readFileSync(join(dir, 'webapp', 'DRAWIO_VERSION'), 'utf8').trim());
+rmSync(dir, { recursive: true, force: true });
+console.log('FEASIBILITY OK');
+EOF
+node "$TMP/drive.mjs"
+rm -rf "$TMP"
+```
+
+Expected output ends with `installed version: v30.0.4` and `FEASIBILITY OK`. If this fails, STOP and investigate before building the UI on top.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/desktop/webappInstaller.ts src/model/installStatus.ts tests/webappInstaller.test.ts
+git commit -m "feat: add offline webapp installer (download + extract + atomic swap)"
+```
+
+---
+
+### Task 4: Load-time detection notice
+
+**Files:**
+- Modify: `src/desktop/registerDesktopFeatures.ts:1` (imports) and end of `registerDesktopFeatures()` (after line 47)
+- Test: `tests/registerDesktopFeatures.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `plugin.isWebappInstalled()` (Task 2).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/registerDesktopFeatures.test.ts`, mock `Notice` at the top of the file (before the existing imports of the module under test):
+
+```ts
+vi.mock('obsidian', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('obsidian')>();
+  return { ...orig, Notice: vi.fn() };
+});
+import { Notice } from 'obsidian';
+```
+
+Extend `fakePlugin()`'s `raw` object with:
+
+```ts
+    settings: {
+      serverPortMin: 3000, serverPortMax: 3999, serverIdleTimeout: 300,
+      drawioMode: 'offline',
+    },
+    isWebappInstalled: vi.fn(async () => true),
+```
+
+Add a `beforeEach(() => { vi.mocked(Notice).mockClear(); })` and these tests:
+
+```ts
+  it('shows a notice when offline mode is set but the webapp is missing', async () => {
+    const { plugin, raw } = fakePlugin();
+    raw.isWebappInstalled = vi.fn(async () => false);
+    await registerDesktopFeatures(plugin);
+    expect(Notice).toHaveBeenCalledWith(
+      expect.stringContaining('offline editor'), expect.any(Number),
+    );
+  });
+
+  it('stays silent when the webapp is installed', async () => {
+    const { plugin } = fakePlugin();
+    await registerDesktopFeatures(plugin);
+    expect(Notice).not.toHaveBeenCalled();
+  });
+
+  it('stays silent in online mode even without the webapp', async () => {
+    const { plugin, raw } = fakePlugin();
+    raw.settings.drawioMode = 'online';
+    raw.isWebappInstalled = vi.fn(async () => false);
+    await registerDesktopFeatures(plugin);
+    expect(Notice).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `npx vitest run tests/registerDesktopFeatures.test.ts`
+Expected: the first new test FAILS (`Notice` never called); pre-existing tests still pass.
+
+- [ ] **Step 3: Implement the notice**
+
+In `src/desktop/registerDesktopFeatures.ts`, extend the obsidian import (line 1):
+
+```ts
+import { FileSystemAdapter, Notice, TFolder } from 'obsidian';
+```
+
+Append at the end of `registerDesktopFeatures()` (after the file-menu registration):
+
+```ts
+  // Lifecycle detection: offline mode selected but the webapp isn't installed.
+  // One notice per plugin load — the settings tab carries the actual installer.
+  if (plugin.settings.drawioMode === 'offline' && !(await plugin.isWebappInstalled())) {
+    new Notice(
+      "Drawio: the offline editor isn't installed — open the plugin settings to " +
+      'install it, or switch the editor source to Online.',
+      10000,
+    );
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/registerDesktopFeatures.test.ts && npx tsc -noEmit -skipLibCheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/desktop/registerDesktopFeatures.ts tests/registerDesktopFeatures.test.ts
+git commit -m "feat: notify at load when offline mode lacks the webapp"
+```
+
+---
+
+### Task 5: Install state tracker + settings-tab UI
+
+**Files:**
+- Modify: `src/model/installStatus.ts` (add state type, `InstallStatus` class, `formatInstallProgress`)
+- Modify: `src/main.ts` (add `webappInstallStatus` field)
+- Modify: `src/settingsTab.ts` (offline status row + install/reinstall flow; update Editor source desc)
+- Modify: `tests/obsidian-stub.ts` (add `ButtonComponent`, `Setting.addButton`, `Setting.descEl`)
+- Test: `tests/installStatus.test.ts` (new), `tests/settingsTab.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `installWebapp` (Task 3, via dynamic import), `isWebappInstalled`/`installedWebappVersion` (Task 2), `InstallProgress` (Task 3).
+- Produces:
+  - `type WebappInstallState = { status: 'idle' } | { status: 'installing'; progressText: string } | { status: 'error'; message: string }`
+  - `class InstallStatus { state: WebappInstallState; set(s): void; subscribe(cb): void }` — single listener, last subscriber wins (there is only ever one settings pane).
+  - `formatInstallProgress(p: InstallProgress): string`
+  - `DrawioPlugin.webappInstallStatus: InstallStatus`
+
+- [ ] **Step 1: Write the failing tracker tests**
+
+Create `tests/installStatus.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { InstallStatus, formatInstallProgress } from '../src/model/installStatus';
+
+describe('InstallStatus', () => {
+  it('notifies the current subscriber on set', () => {
+    const s = new InstallStatus();
+    const cb = vi.fn();
+    s.subscribe(cb);
+    s.set({ status: 'installing', progressText: 'Downloading… 10%' });
+    expect(s.state).toEqual({ status: 'installing', progressText: 'Downloading… 10%' });
+    expect(cb).toHaveBeenCalledWith({ status: 'installing', progressText: 'Downloading… 10%' });
+  });
+
+  it('replaces the previous subscriber (settings re-render)', () => {
+    const s = new InstallStatus();
+    const first = vi.fn();
+    const second = vi.fn();
+    s.subscribe(first);
+    s.subscribe(second);
+    s.set({ status: 'idle' });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalled();
+  });
+});
+
+describe('formatInstallProgress', () => {
+  it('formats download with a known total as a percentage', () => {
+    expect(formatInstallProgress({ phase: 'download', received: 26_500_000, total: 53_000_000 }))
+      .toBe('Downloading… 50%');
+  });
+
+  it('formats download without a total as received MB', () => {
+    expect(formatInstallProgress({ phase: 'download', received: 5 * 1024 * 1024, total: null }))
+      .toBe('Downloading… 5.0 MB');
+  });
+
+  it('formats extraction', () => {
+    expect(formatInstallProgress({ phase: 'extract' })).toBe('Extracting…');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/installStatus.test.ts`
+Expected: FAIL — `InstallStatus` not exported.
+
+- [ ] **Step 3: Implement tracker + formatter**
+
+Append to `src/model/installStatus.ts`:
+
+```ts
+/** UI-facing install state, held on the plugin instance so it outlives
+ * settings-tab re-renders (display() rebuilds the whole pane at any time). */
+export type WebappInstallState =
+  | { status: 'idle' }
+  | { status: 'installing'; progressText: string }
+  | { status: 'error'; message: string };
+
+/** Single-listener state holder: the settings row re-subscribes on every
+ * render, and only one settings pane exists, so last-subscriber-wins is
+ * exactly the right semantics. */
+export class InstallStatus {
+  state: WebappInstallState = { status: 'idle' };
+  private listener: ((s: WebappInstallState) => void) | null = null;
+
+  set(state: WebappInstallState): void {
+    this.state = state;
+    this.listener?.(state);
+  }
+
+  subscribe(cb: (s: WebappInstallState) => void): void {
+    this.listener = cb;
+  }
+}
+
+export function formatInstallProgress(p: InstallProgress): string {
+  if (p.phase === 'extract') return 'Extracting…';
+  if (p.total) return `Downloading… ${Math.floor((p.received / p.total) * 100)}%`;
+  return `Downloading… ${(p.received / (1024 * 1024)).toFixed(1)} MB`;
+}
+```
+
+In `src/main.ts`, import and add the field after `server`:
+
+```ts
+import { InstallStatus } from './model/installStatus';
+```
+
+```ts
+  /** Offline-webapp install state — on the plugin (not the settings tab) so a
+   * mid-install settings re-render can re-attach to the running install. */
+  webappInstallStatus = new InstallStatus();
+```
+
+Run: `npx vitest run tests/installStatus.test.ts` — expected PASS.
+
+- [ ] **Step 4: Extend the obsidian stub**
+
+In `tests/obsidian-stub.ts`, add a `ButtonComponent` class (next to the other component classes) and wire `Setting`:
+
+```ts
+export class ButtonComponent {
+  buttonEl: HTMLButtonElement = document.createElement('button');
+  setButtonText(t: string): this { this.buttonEl.textContent = t; return this; }
+  setCta(): this { return this; }
+  setDisabled(d: boolean): this { this.buttonEl.disabled = d; return this; }
+  onClick(cb: (evt: MouseEvent) => unknown): this {
+    this.buttonEl.addEventListener('click', () => { void cb(new MouseEvent('click')); });
+    return this;
+  }
+}
+```
+
+In the `Setting` stub: add a public `descEl`, create/append it in the constructor (class `setting-item-description`), make `setDesc` write `descEl.textContent`, and add:
+
+```ts
+  addButton(cb: (b: ButtonComponent) => unknown): this {
+    const b = new ButtonComponent();
+    this.settingEl.appendChild(b.buttonEl);
+    cb(b);
+    return this;
+  }
+```
+
+- [ ] **Step 5: Write the failing settings-tab tests**
+
+In `tests/settingsTab.test.ts`, extend `fakePlugin()` to accept overrides:
+
+```ts
+import { InstallStatus } from '../src/model/installStatus';
+
+function fakePlugin(overrides: Record<string, unknown> = {}): DrawioPlugin {
+  return {
+    settings: { ...DEFAULT_SETTINGS },
+    saveSettings: async () => {},
+    updateServerIdleTimeout: () => {},
+    webappInstallStatus: new InstallStatus(),
+    isWebappInstalled: async () => false,
+    installedWebappVersion: async () => null,
+    server: null,
+    ...overrides,
+  } as unknown as DrawioPlugin;
+}
+```
+
+Add a new describe block:
+
+```ts
+describe('offline editor status row', () => {
+  const originalIsDesktopApp = Platform.isDesktopApp;
+  afterEach(() => { Platform.isDesktopApp = originalIsDesktopApp; });
+
+  function statusRow(containerEl: HTMLElement): HTMLElement | null {
+    return Array.from(containerEl.querySelectorAll('.setting-item')).find((el) =>
+      el.querySelector('.setting-item-name')?.textContent === 'Offline editor',
+    ) as HTMLElement ?? null;
+  }
+
+  it('is shown in offline mode and offers Install when not installed', async () => {
+    Platform.isDesktopApp = true;
+    const tab = new DrawioSettingTab({} as never, fakePlugin());
+    tab.display();
+    const row = statusRow(tab.containerEl);
+    expect(row).not.toBeNull();
+    await vi.waitFor(() => {
+      expect(row!.querySelector('button')?.textContent).toBe('Install');
+      expect(row!.querySelector('.setting-item-description')?.textContent).toContain('Not installed');
+    });
+  });
+
+  it('offers Reinstall and shows the version when installed', async () => {
+    Platform.isDesktopApp = true;
+    const tab = new DrawioSettingTab({} as never, fakePlugin({
+      isWebappInstalled: async () => true,
+      installedWebappVersion: async () => 'v30.0.4',
+    }));
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    await vi.waitFor(() => {
+      expect(row.querySelector('button')?.textContent).toBe('Reinstall');
+      expect(row.querySelector('.setting-item-description')?.textContent).toContain('v30.0.4');
+    });
+  });
+
+  it('renders live progress while an install is running', async () => {
+    Platform.isDesktopApp = true;
+    const plugin = fakePlugin();
+    (plugin as unknown as { webappInstallStatus: InstallStatus }).webappInstallStatus
+      .set({ status: 'installing', progressText: 'Downloading… 42%' });
+    const tab = new DrawioSettingTab({} as never, plugin);
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    expect(row.querySelector('.setting-item-description')?.textContent).toBe('Downloading… 42%');
+    expect(row.querySelector<HTMLButtonElement>('button')?.disabled).toBe(true);
+  });
+
+  it('is absent in online mode', () => {
+    Platform.isDesktopApp = true;
+    const plugin = fakePlugin();
+    (plugin as unknown as { settings: { drawioMode: string } }).settings.drawioMode = 'online';
+    const tab = new DrawioSettingTab({} as never, plugin);
+    tab.display();
+    expect(statusRow(tab.containerEl)).toBeNull();
+  });
+});
+```
+
+Also import `vi` in the test file's vitest import.
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `npx vitest run tests/settingsTab.test.ts`
+Expected: new tests FAIL (no 'Offline editor' row rendered).
+
+- [ ] **Step 7: Implement the settings row**
+
+In `src/settingsTab.ts`:
+
+Imports (top of file):
+
+```ts
+import { App, ButtonComponent, Platform, PluginSettingTab, Setting } from 'obsidian';
+import { formatInstallProgress, type WebappInstallState } from './model/installStatus';
+```
+
+Update the Editor source desc (line 28-32) — drop the fallback sentence:
+
+```ts
+        .setDesc(
+          'Offline (default) uses the bundled editor served locally — fully offline, no network. ' +
+          'Online loads the editor from diagrams.net. Or point at a custom embed URL. The offline ' +
+          'editor requires a one-time install — see below when Offline is selected.',
+        )
+```
+
+After the custom-URL block (after line 57), add:
+
+```ts
+      // Offline-editor install status + one-click installer.
+      if (s.drawioMode === 'offline') {
+        this.renderOfflineEditorStatus(containerEl);
+      }
+```
+
+Add these methods to the class:
+
+```ts
+  /** Status row for the bundled offline editor: detection is async (disk
+   * check), so the row renders a checking state and fills itself in; while an
+   * install runs, the row re-subscribes to the plugin-held status each render
+   * so progress survives full display() re-renders. */
+  private renderOfflineEditorStatus(containerEl: HTMLElement): void {
+    const setting = new Setting(containerEl).setName('Offline editor');
+    let button!: ButtonComponent;
+    setting.addButton((b) => {
+      button = b;
+      b.onClick(() => { void this.startInstall(); });
+    });
+
+    const status = this.plugin.webappInstallStatus;
+    const refresh = async (state: WebappInstallState) => {
+      if (state.status === 'installing') {
+        setting.setDesc(state.progressText);
+        button.setButtonText('Installing…').setDisabled(true);
+        return;
+      }
+      if (state.status === 'error') {
+        setting.setDesc(`Install failed: ${state.message}`);
+        button.setButtonText('Retry').setDisabled(false);
+        return;
+      }
+      // idle → check the disk.
+      setting.setDesc('Checking installation…');
+      button.setButtonText('Install').setDisabled(true);
+      const installed = await this.plugin.isWebappInstalled();
+      if (status.state.status !== 'idle') return; // an install started meanwhile
+      if (installed) {
+        const version = await this.plugin.installedWebappVersion();
+        setting.setDesc(version ? `Installed (drawio ${version}).` : 'Installed.');
+        button.setButtonText('Reinstall').setDisabled(false);
+      } else {
+        setting.setDesc(
+          'Not installed. Installing downloads ~53 MB from GitHub (one time, needs network); ' +
+          'editing is fully offline afterwards. Reinstalling interrupts any open offline editor.',
+        );
+        button.setButtonText('Install').setCta().setDisabled(false);
+      }
+    };
+    status.subscribe((state) => { void refresh(state); });
+    void refresh(status.state);
+  }
+
+  /** Runs the installer, publishing progress through the plugin-held status.
+   * Stops the local server first: on Windows an open handle inside webapp/
+   * would make the atomic swap fail. */
+  private async startInstall(): Promise<void> {
+    const status = this.plugin.webappInstallStatus;
+    if (status.state.status === 'installing') return;
+    this.plugin.server?.stop();
+    status.set({ status: 'installing', progressText: 'Starting download…' });
+    try {
+      const { installWebapp } = await import('./desktop/webappInstaller');
+      await installWebapp(await this.plugin.pluginDir(), (p) => {
+        status.set({ status: 'installing', progressText: formatInstallProgress(p) });
+      });
+      status.set({ status: 'idle' });
+    } catch (e) {
+      status.set({ status: 'error', message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+```
+
+Note: `startInstall` runs to completion even if the settings pane closes (the promise is held by the closure, and state updates against a detached row's DOM are harmless); reopening settings re-subscribes and shows current progress. No cancellation — YAGNI per spec.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `npx vitest run && npx tsc -noEmit -skipLibCheck`
+Expected: all PASS (viewer-dependent suites still skip).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/model/installStatus.ts src/main.ts src/settingsTab.ts tests/obsidian-stub.ts tests/installStatus.test.ts tests/settingsTab.test.ts
+git commit -m "feat: settings-tab offline editor status row with one-click install"
+```
+
+---
+
+### Task 6: Documentation + full verification
+
+**Files:**
+- Modify: `README.md` (lines 15, 26, 62, 78, and the "Offline editor (optional)" section at 80-88)
+- Modify: `CLAUDE.md` (module-map `resolveBaseUrl` line; the "Default editor mode" non-obvious-decision bullet)
+
+**Interfaces:** none — documentation only, then whole-feature verification.
+
+- [ ] **Step 1: Update README.md**
+
+Replace line 15 (`- **Offline editor, optionally** — ...`) with:
+
+```md
+- **Offline editor, optionally** — the editor defaults to a bundled, fully offline drawio build served from a local server. Store installs don't include the bundle (~145 MB); install it with one click from the plugin settings, or switch the editor source to Online.
+```
+
+Replace line 26 (`No extra setup is needed: ...`) with:
+
+```md
+The editor needs one of: the offline editor installed (one click in settings, ~53 MB download), or **Editor source → Online** in the plugin settings.
+```
+
+Replace line 62's Editor source row description sentence `Offline falls back to Online automatically when the bundled webapp isn't installed.` with:
+
+```md
+Offline requires the one-time install below — there is no automatic fallback.
+```
+
+Replace line 78 (`- **When the bundle isn't installed** ...`) with:
+
+```md
+- **When the bundle isn't installed**, Offline mode shows an install prompt instead of silently going online. If you choose **Online** (or a Custom URL), the editor UI is loaded from that origin. Your diagram content still stays on your device — it is passed to the editor in the page and is **not uploaded**; only the editor's assets are fetched.
+```
+
+Rewrite the "Offline editor (optional)" section (lines 80-88) as:
+
+```md
+## Offline editor (optional)
+
+A store install ships without the offline drawio webapp (it is ~145 MB, beyond store limits). To install it, open **Settings → Drawio**, select **Editor source → Offline (bundled webapp)**, and click **Install** — a one-time ~53 MB download from GitHub; editing is fully offline afterwards.
+
+Building from source also works and produces the same layout: run `npm run fetch-drawio` before `npm run build` and copy the `webapp/` folder alongside `main.js` (see Development below).
+```
+
+Keep the rest of the section's surrounding content intact; read the actual file before editing — line numbers may have drifted.
+
+- [ ] **Step 2: Update CLAUDE.md**
+
+In the module map, change the `resolveBaseUrl()` sentence to:
+
+```md
+  `resolveBaseUrl()` picks the editor URL (offline → local server; throws a typed
+  `OfflineEditorNotInstalledError` when the webapp isn't installed — **no automatic
+  online fallback** since 0.5.x).
+```
+
+Replace the non-obvious-decision bullet `- **Default editor mode is \`offline\`** with automatic online fallback. ...` with:
+
+```md
+- **Default editor mode is `offline`, with NO automatic online fallback** (the
+  fallback existed through 0.4.x and was removed on purpose — don't reintroduce
+  it). The ~145 MB `webapp/` can't ship via the store, so store installs start
+  without it: `resolveBaseUrl()` throws `OfflineEditorNotInstalledError`
+  (`src/model/errors.ts`), whose message both editor entry points surface, and
+  the settings tab offers a one-click installer
+  (`src/desktop/webappInstaller.ts`: `node:https` download of the pinned
+  `draw.war` → `fflate` extract to `webapp.installing/` → validate → atomic
+  rename to `webapp/`; the caller stops the local server first for Windows file
+  locks). `fflate` is a devDependency inlined by esbuild. The pinned version
+  lives in `src/constants.ts` (`DRAWIO_VERSION`) and a test asserts it matches
+  `scripts/fetch-drawio.mjs`. A load-time notice
+  (`registerDesktopFeatures.ts`) points offline-mode users at settings when
+  the webapp is missing.
+```
+
+- [ ] **Step 3: Full verification**
+
+```bash
+npm run fetch-drawio   # populates webapp/ + viewer.min.txt so ALL suites run
+npm test
+npm run build
+```
+
+Expected: fetch succeeds; the previously-skipped viewer suites now run and pass; `tsc` + esbuild produce `main.js` with no errors (the guard plugins pass).
+
+- [ ] **Step 4: Grep for stragglers**
+
+```bash
+grep -rn "fallback" src/ README.md CLAUDE.md | grep -vi "no automatic\|no fallback\|falls back to an older"
+grep -n "warnedOfflineFallback" -r src/ tests/
+```
+
+Expected: no hits describing the old offline→online fallback behavior; `warnedOfflineFallback` gone.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: describe offline install flow; remove fallback wording"
+```
+
+---
+
+## Post-plan notes (for the session driving this plan)
+
+- **Release-notes callout (when a release is next cut, not part of this plan):** store users who never touched settings were silently using the online editor; after this change they get an install prompt instead. State this prominently.
+- **Manual E2E** (cannot be automated here): copy `main.js`/`manifest.json`/`styles.css` into a dev vault **without** `webapp/`, set Offline mode, confirm: load notice appears; opening an editor shows the instructive error; settings shows "Not installed" + Install; clicking Install shows progress then "Installed (drawio v30.0.4)"; editor then opens offline; Reinstall works.
+- No version bump in this plan — releases are cut separately per CLAUDE.md's release process.

--- a/docs/superpowers/specs/2026-07-11-offline-webapp-install-design.md
+++ b/docs/superpowers/specs/2026-07-11-offline-webapp-install-design.md
@@ -1,0 +1,172 @@
+# 设计：离线编辑器（webapp）的检测与一键安装
+
+日期：2026-07-11
+状态：已与用户确认方向，待实施
+
+## 背景与动机
+
+插件默认编辑器模式为 `offline`，依赖插件目录下约 145 MB 的 `webapp/`
+（解压自 drawio 官方 `draw.war`）。商店安装无法携带该目录，现行为是
+`resolveBaseUrl()` 检测到缺失后**静默回退**到 `ONLINE_DRAWIO_URL`
+（一次性 Notice）。
+
+本变更移除自动回退，改为**显式检测 + 设置页一键安装**：
+
+- 用户选择 offline 即意味着 offline——不再悄悄改用在线编辑器。
+- 未安装时给出明确、可操作的引导（设置页安装按钮），而非降级。
+
+用户已确认的决定：
+
+1. 默认模式**保持 `offline`**（不改为 online）。
+2. 插件生命周期中加入环境检测；检测到未安装时设置页提供安装按钮。
+3. 进度粒度：下载阶段显示百分比，解压阶段仅显示"解压中…"。
+4. 已安装状态下保留"重新安装"按钮（用于损坏修复/升级）。
+
+## 范围
+
+- 桌面端专属。mobile 本就只有预览，不受影响（`settingsTab.ts` 的
+  offline 区块已在 `Platform.isDesktopApp` 内）。
+- 不改动预览引擎（viewer）、不改动 online/custom 模式行为。
+
+## 组件设计
+
+### 1. 检测 `DrawioPlugin.isWebappInstalled(): Promise<boolean>`
+
+- 判据与现行 `resolveBaseUrl()` 一致：`<pluginDir>/webapp/index.html`
+  存在即视为已安装。
+- 方法体内动态 `await import('node:fs')`/`import('node:path')`，仅桌面
+  调用（与 `pluginDir()` 同一纪律，见 CLAUDE.md 移动端导入约束）。
+- 调用方（生命周期三触点）：
+  1. **加载时**：`registerDesktopFeatures()` 中，若 `drawioMode ===
+     'offline'` 且未安装，弹一次性 Notice 引导去设置页（每次会话最多
+     一次；不自动打开设置页）。
+  2. **设置页**：渲染检测状态与安装按钮（见 §4）。
+  3. **编辑入口**：`resolveBaseUrl()`（见 §3）。
+
+### 2. 安装流水线 `src/desktop/webappInstaller.ts`
+
+位于 `src/desktop/**`（该目录允许静态 node 导入；只被设置页点击
+处理器动态 import，mobile 永不加载）。
+
+```
+installWebapp(pluginDir: string, onProgress: (p: InstallProgress) => void): Promise<void>
+type InstallProgress =
+  | { phase: 'download'; received: number; total: number | null }
+  | { phase: 'extract' }
+```
+
+步骤：
+
+1. **下载**：`node:https` GET `draw.war`（约 53 MB，版本与 URL 见
+   §5），手动跟随 30x 重定向（GitHub releases 302 到对象存储）。选
+   `node:https` 而非 `fetch`/`requestUrl`：可流式报进度、无 CORS 顾虑。
+   数据累积在内存 Buffer（53 MB 桌面端可接受，免去临时文件清理）。
+2. **完整性**：若响应带 `content-length`，接收完成后核对字节数，不符
+   即报错。
+3. **解压**：`fflate.unzipSync` 解压 Buffer，写入
+   `<pluginDir>/webapp.installing/`；跳过 `WEB-INF/`、`META-INF/`
+   （与 `scripts/fetch-drawio.mjs` 一致）。
+4. **校验**：`index.html` 与 `js/viewer.min.js` 必须存在；写
+   `DRAWIO_VERSION` 文件（内容同构建脚本格式）。
+5. **原子落位**：删除旧 `webapp/`（若存在），`fs.renameSync`
+   `webapp.installing` → `webapp`。
+6. **失败清理**：任一步失败删除 `webapp.installing/`，原 `webapp/`
+   保持不动，错误上抛给设置页展示。
+
+依赖：`fflate` 加入 **devDependencies**（esbuild 内联进 `main.js`，
+运行时零外部依赖；tree-shaking 后体积增量很小）。它是真实被导入使用
+的——不同于历史上被移除的未使用 `dompurify`。
+
+**重装的文件锁问题（Windows）**：本地服务器可能正持有 `webapp/` 内
+文件句柄。安装流程开始前由调用方（设置页）先 `plugin.server?.stop()`；
+按钮说明注明重装会中断正在进行的离线编辑会话。
+
+### 3. `resolveBaseUrl()` 行为变更（移除回退）
+
+- offline + 已安装 → 不变（起本地服务器）。
+- offline + 未安装 → 抛 `OfflineEditorNotInstalledError`（定义于
+  `src/model/errors.ts`，纯 TS 无 node 依赖，可被任意端安全导入）。
+  message 即面向用户的文案：提示到设置页安装离线编辑器，或切换
+  Online 模式。
+- 删除 `warnedOfflineFallback` 字段与回退 Notice。
+- 错误路径复用两个编辑入口**现有**的错误处理：
+  - `DrawioModal.onOpen` 的 try/catch：识别该错误类型时，Notice 直接
+    展示其 message（替代泛化的 "failed to open editor" 文案），错误
+    div 同样展示 message。
+  - `DrawioFileView.mountEditor` 的 `.catch`：错误 div 展示 message。
+- 不会出现空白 iframe：`mount()` 在 `resolveBaseUrl()` 抛出时尚未创建
+  iframe。
+
+### 4. 设置页 UI（`settingsTab.ts`，仅 `drawioMode === 'offline'` 时渲染，紧随 Editor source 之后）
+
+- `display()` 同步渲染"检测中…"占位；异步 `isWebappInstalled()` 完成
+  后就地回填（不整页重渲染）。
+- **未安装**：状态"离线编辑器未安装" + 按钮 `Install offline editor`
+  + 说明（约 53 MB 下载、安装时需联网、装好后编辑完全离线）。
+- **安装中**：按钮禁用；就地更新进度文本（`Downloading… 45%` /
+  `Extracting…`）。
+- **已安装**：状态"已安装"，版本号从 `webapp/DRAWIO_VERSION` 文件
+  实读（手动安装可能无此文件或版本不同——无文件则不显示版本号）；
+  附次级按钮 `Reinstall`（同一流水线，先停服务器）。
+- **失败**：就地显示错误信息，按钮恢复可点（重试）。
+- **重渲染韧性**：安装状态（idle/installing+进度/error）保存在
+  plugin 实例字段上；`display()` 每次渲染读取当前状态并重新订阅进度
+  回调，因此安装期间用户改动其他设置触发的整页重渲染不会丢失进度
+  显示。安装完成后刷新整页（`this.display()`）以切到"已安装"态。
+- "Editor source" 下拉的描述文案更新：删去"未安装时自动使用在线
+  编辑器"的表述。
+
+### 5. 版本固定与防漂移
+
+- `src/constants.ts` 新增 `DRAWIO_VERSION = 'v30.0.4'` 与
+  `DRAWIO_WAR_URL`（或构造函数），运行时安装器使用，保证与内联
+  `viewer.min.txt` 同版本。
+- `scripts/fetch-drawio.mjs` 保持自带版本字符串（ESM node 脚本直接
+  import TS 常量不便），以单测断言两处版本一致来防漂移（见测试 §4）。
+
+## 错误处理汇总
+
+| 场景 | 行为 |
+| --- | --- |
+| offline 编辑但未安装 | 类型化错误，入口展示可操作文案（设置页安装 / 切 Online） |
+| 下载网络失败 / 字节数不符 | 清理临时目录，设置页显示错误，可重试 |
+| zip 解析失败 / 校验缺文件 | 同上 |
+| 重装时服务器占用文件 | 先停服务器规避；rename 仍失败则同上报错 |
+| 安装中途关闭 Obsidian | 残留 `webapp.installing/` 不影响检测（判据是 `webapp/index.html`）；下次安装开始时先删除残留 |
+
+## 测试
+
+均为 vitest 单测，无网络：
+
+1. `isWebappInstalled`：临时目录两分支。
+2. 解压/过滤：测试内用 `fflate.zipSync` 构造含
+   `index.html`、`js/viewer.min.js`、`WEB-INF/x`、`META-INF/x` 的小
+   zip，断言输出目录正确、WEB-INF/META-INF 被剔除、`DRAWIO_VERSION`
+   写入、rename 落位。
+3. 校验失败路径：缺 `index.html` 的 zip → 抛错且 `webapp.installing`
+   被清理、原 `webapp/` 未动。
+4. 版本同步：断言 `scripts/fetch-drawio.mjs` 文本中的版本与
+   `constants.ts` 一致。
+5. `resolveBaseUrl`：offline 未安装 → 抛 `OfflineEditorNotInstalledError`；
+   已安装分支不变（现有测试若覆盖回退行为则更新）。
+
+真实下载不进单测：实施第一步先做一次性可行性脚本（真下载 + fflate
+解压到临时目录）验证最大风险点，通过后再建 UI。
+
+## 文档更新
+
+- **CLAUDE.md**："Default editor mode is offline with automatic online
+  fallback" 条目重述为新行为（无回退、检测、安装按钮、fflate 内联）。
+- **README**：删去自动回退表述，改为设置页一键安装说明。
+- **发布说明**：显著标注行为变更——商店安装且从未改过设置的用户，
+  升级后首次编辑会看到安装引导而非静默使用在线编辑器。
+
+## 兼容性核对（CLAUDE.md 检查单逐项）
+
+- node 导入：新增 node API 调用要么在 `src/desktop/**`（静态导入
+  允许），要么方法体内动态 import（`isWebappInstalled`）。依赖
+  esbuild `supported: { 'dynamic-import': false }` 降级，不动该配置。
+- 无新增 Obsidian API（`Notice`/`Setting`/`ButtonComponent` 均为
+  基线 API，现有代码已在用）。
+- 无 regex 字面量新风险；不创建 `<script>`；不触碰 viewer/sanitizer。
+- `onunload` 不变。

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/node": "^22.15.17",
         "esbuild": "0.25.5",
+        "fflate": "^0.8.3",
         "jsdom": "^25.0.1",
         "obsidian": "latest",
         "typescript": "^5.8.3",
@@ -1434,6 +1435,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.15.17",
     "esbuild": "0.25.5",
+    "fflate": "^0.8.3",
     "jsdom": "^25.0.1",
     "obsidian": "latest",
     "typescript": "^5.8.3",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,16 @@ export const DRAWIO_FILE_EXT = 'drawio';
 /** Hosted drawio embed, used when the editor source is "Online" (the default). */
 export const ONLINE_DRAWIO_URL = 'https://embed.diagrams.net/';
 
+/** Pinned drawio version — MUST match scripts/fetch-drawio.mjs (guarded by
+ * tests/drawioVersionSync.test.ts) so the runtime-installed webapp matches the
+ * bundled viewer.min.txt. */
+export const DRAWIO_VERSION = 'v30.0.4';
+
+/** The pinned drawio webapp archive (a ZIP), downloaded by the settings-tab
+ * one-click installer. */
+export const DRAWIO_WAR_URL =
+  `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`;
+
 /** Default empty mxfile diagram. */
 export const EMPTY_DIAGRAM =
   '<mxfile><diagram id="0" name="Page-1"><mxGraphModel dx="800" dy="600" grid="1" ' +

--- a/src/desktop/registerDesktopFeatures.ts
+++ b/src/desktop/registerDesktopFeatures.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, TFolder } from 'obsidian';
+import { FileSystemAdapter, Notice, TFolder } from 'obsidian';
 import { join } from 'node:path';
 import { ServerManager } from '../server/ServerManager';
 import { createNewDiagram } from '../file/createDiagram';
@@ -45,4 +45,14 @@ export async function registerDesktopFeatures(plugin: DrawioPlugin): Promise<voi
         .onClick(() => { void createNewDiagram(plugin, file); }));
     }
   }));
+
+  // Lifecycle detection: offline mode selected but the webapp isn't installed.
+  // One notice per plugin load — the settings tab carries the actual installer.
+  if (plugin.settings.drawioMode === 'offline' && !(await plugin.isWebappInstalled())) {
+    new Notice(
+      "Drawio: the offline editor isn't installed — open the plugin settings to " +
+      'install it, or switch the editor source to Online.',
+      10000,
+    );
+  }
 }

--- a/src/desktop/webappInstaller.ts
+++ b/src/desktop/webappInstaller.ts
@@ -30,7 +30,8 @@ export async function installWebapp(
 
 /** The post-download half, separated for network-free testing: extract into a
  * staging dir, validate, then atomically swap into place. On any failure the
- * staging dir is removed and an existing webapp/ is left untouched. */
+ * staging dir is removed; an existing webapp/ is either left fully in place
+ * or fully restored — see `swapWebappIntoPlace`. */
 export function installFromWar(war: Uint8Array, pluginDir: string): void {
   const staging = join(pluginDir, 'webapp.installing');
   rmSync(staging, { recursive: true, force: true });
@@ -42,12 +43,59 @@ export function installFromWar(war: Uint8Array, pluginDir: string): void {
       }
     }
     writeFileSync(join(staging, 'DRAWIO_VERSION'), DRAWIO_VERSION + '\n');
-    const dest = join(pluginDir, 'webapp');
-    rmSync(dest, { recursive: true, force: true });
-    renameSync(staging, dest);
+    swapWebappIntoPlace(pluginDir);
   } catch (e) {
+    // After a successful swap this rmSync targets a staging dir that no
+    // longer exists — force:true makes that a harmless no-op.
     rmSync(staging, { recursive: true, force: true });
     throw e;
+  }
+}
+
+/**
+ * Swap <pluginDir>/webapp.installing into <pluginDir>/webapp via
+ * rename-aside, so an existing webapp/ is either fully in place or fully
+ * restored — never partially deleted. A plain "rmSync(dest) then
+ * renameSync(staging, dest)" can leave NO webapp at all if the delete is a
+ * recursive tree removal that throws partway (e.g. a locked file on
+ * Windows) or if the rename itself fails after the delete already
+ * succeeded. Directory renames are single atomic filesystem operations —
+ * they either happen or don't — so renaming the old webapp/ aside first
+ * (instead of deleting it) means any later failure can roll it straight
+ * back into place.
+ *
+ * A `webapp.old/` leftover may remain only if the process crashes between
+ * the aside-rename and the final cleanup below; it is harmless (not read by
+ * anything) and is cleared automatically at the top of the next install.
+ *
+ * Exported for tests: the rollback path needs failure injection (a missing
+ * staging dir stands in for a swap that fails partway).
+ */
+export function swapWebappIntoPlace(pluginDir: string): void {
+  const staging = join(pluginDir, 'webapp.installing');
+  const dest = join(pluginDir, 'webapp');
+  const old = join(pluginDir, 'webapp.old');
+
+  rmSync(old, { recursive: true, force: true }); // leftover from a past interrupted swap
+  let oldAside = false;
+  if (existsSync(dest)) {
+    renameSync(dest, old); // atomic: on failure, dest is fully intact
+    oldAside = true;
+  }
+  try {
+    renameSync(staging, dest);
+  } catch (e) {
+    if (oldAside) renameSync(old, dest); // roll the old install back into place
+    throw e;
+  }
+  if (oldAside) {
+    try {
+      rmSync(old, { recursive: true, force: true });
+    } catch {
+      // The install itself succeeded; a locked leftover webapp.old is
+      // cleared by the next install's leading rmSync. Don't fail a
+      // successful install over cleanup of the old copy.
+    }
   }
 }
 

--- a/src/desktop/webappInstaller.ts
+++ b/src/desktop/webappInstaller.ts
@@ -1,0 +1,116 @@
+import { get } from 'node:https';
+import {
+  existsSync, mkdirSync, renameSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { dirname, join, normalize, sep } from 'node:path';
+import { unzipSync } from 'fflate';
+import { DRAWIO_VERSION, DRAWIO_WAR_URL } from '../constants';
+import type { InstallProgress } from '../model/installStatus';
+
+/** Top-level directories in draw.war that are server-only and never served
+ * (same exclusions as scripts/fetch-drawio.mjs). */
+const SKIP_PREFIXES = ['WEB-INF/', 'META-INF/'];
+
+/**
+ * Download the pinned drawio webapp and install it into `<pluginDir>/webapp`.
+ * The caller (settings tab) must stop the local server first — on Windows an
+ * open file handle inside webapp/ would make the final swap fail.
+ *
+ * The whole archive (~53 MB) is buffered in memory: it spares a temp file and
+ * its cleanup, and is well within desktop Electron's budget.
+ */
+export async function installWebapp(
+  pluginDir: string,
+  onProgress: (p: InstallProgress) => void,
+): Promise<void> {
+  const war = await download(DRAWIO_WAR_URL, onProgress);
+  onProgress({ phase: 'extract' });
+  installFromWar(war, pluginDir);
+}
+
+/** The post-download half, separated for network-free testing: extract into a
+ * staging dir, validate, then atomically swap into place. On any failure the
+ * staging dir is removed and an existing webapp/ is left untouched. */
+export function installFromWar(war: Uint8Array, pluginDir: string): void {
+  const staging = join(pluginDir, 'webapp.installing');
+  rmSync(staging, { recursive: true, force: true });
+  try {
+    extract(war, staging);
+    for (const f of ['index.html', join('js', 'viewer.min.js')]) {
+      if (!existsSync(join(staging, f))) {
+        throw new Error(`The downloaded webapp is missing ${f} — aborting install.`);
+      }
+    }
+    writeFileSync(join(staging, 'DRAWIO_VERSION'), DRAWIO_VERSION + '\n');
+    const dest = join(pluginDir, 'webapp');
+    rmSync(dest, { recursive: true, force: true });
+    renameSync(staging, dest);
+  } catch (e) {
+    rmSync(staging, { recursive: true, force: true });
+    throw e;
+  }
+}
+
+function extract(war: Uint8Array, destDir: string): void {
+  const entries = unzipSync(war, {
+    filter: (f) => !SKIP_PREFIXES.some((p) => f.name.startsWith(p)),
+  });
+  for (const [name, data] of Object.entries(entries)) {
+    if (name.endsWith('/')) continue; // directory entry
+    const target = normalize(join(destDir, name));
+    // Zip-slip guard: the source is a pinned HTTPS URL, but entry names are
+    // still attacker-shaped input in principle — never write outside destDir.
+    if (!target.startsWith(destDir + sep)) {
+      throw new Error(`Unsafe zip entry path: ${name}`);
+    }
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, data);
+  }
+}
+
+/** GET with redirect following (GitHub release assets 302 to object storage).
+ * node:https rather than fetch/requestUrl: streams progress and needs no CORS. */
+function download(
+  url: string,
+  onProgress: (p: InstallProgress) => void,
+  redirects = 0,
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    if (redirects > 5) {
+      reject(new Error(`Too many redirects downloading ${url}`));
+      return;
+    }
+    const req = get(url, (res) => {
+      const status = res.statusCode ?? 0;
+      const location = res.headers.location;
+      if (status >= 300 && status < 400 && location) {
+        res.resume();
+        resolve(download(new URL(location, url).toString(), onProgress, redirects + 1));
+        return;
+      }
+      if (status !== 200) {
+        res.resume();
+        reject(new Error(`Download failed: HTTP ${status} for ${url}`));
+        return;
+      }
+      const lenHeader = res.headers['content-length'];
+      const total = lenHeader ? Number(lenHeader) : null;
+      const chunks: Buffer[] = [];
+      let received = 0;
+      res.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+        received += chunk.length;
+        onProgress({ phase: 'download', received, total });
+      });
+      res.on('end', () => {
+        if (total !== null && received !== total) {
+          reject(new Error(`Download incomplete: got ${received} of ${total} bytes`));
+          return;
+        }
+        resolve(Buffer.concat(chunks));
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+  });
+}

--- a/src/desktop/webappInstaller.ts
+++ b/src/desktop/webappInstaller.ts
@@ -25,7 +25,25 @@ export async function installWebapp(
 ): Promise<void> {
   const war = await download(DRAWIO_WAR_URL, onProgress);
   onProgress({ phase: 'extract' });
+  // unzipSync + thousands of sync writes block the renderer's main thread;
+  // without a committed frame first, the "Extracting…" label never paints and
+  // the UI freezes on a stale download percentage. Double-rAF guarantees a
+  // frame commit; the trailing setTimeout yields the macrotask before we block.
+  await nextPaint();
   installFromWar(war, pluginDir);
+}
+
+/** Resolve after the renderer has committed a frame (double-rAF), then one
+ * macrotask later — the last chance to show fresh progress text before a
+ * long synchronous block. */
+function nextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    activeWindow.requestAnimationFrame(() => {
+      activeWindow.requestAnimationFrame(() => {
+        activeWindow.setTimeout(resolve, 0);
+      });
+    });
+  });
 }
 
 /** The post-download half, separated for network-free testing: extract into a
@@ -45,8 +63,10 @@ export function installFromWar(war: Uint8Array, pluginDir: string): void {
     writeFileSync(join(staging, 'DRAWIO_VERSION'), DRAWIO_VERSION + '\n');
     swapWebappIntoPlace(pluginDir);
   } catch (e) {
-    // After a successful swap this rmSync targets a staging dir that no
-    // longer exists — force:true makes that a harmless no-op.
+    // A successful swap never reaches here — this only runs when extract,
+    // validation, or the swap itself failed before or during the staging
+    // rename, so staging still exists (or, if the swap already renamed it
+    // away, force:true makes this a harmless no-op).
     rmSync(staging, { recursive: true, force: true });
     throw e;
   }

--- a/src/editor/DrawioModal.ts
+++ b/src/editor/DrawioModal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, Notice } from 'obsidian';
 import { DrawioSource } from '../model/DrawioSource';
 import { DrawioEditor, DrawioEditorDeps } from './DrawioEditor';
+import { OfflineEditorNotInstalledError } from '../model/errors';
 
 /**
  * Full-screen modal wrapping a {@link DrawioEditor}. Used for editing code-block
@@ -23,8 +24,14 @@ export class DrawioModal extends Modal {
       await this.editor.mount();
     } catch (err) {
       console.error('[drawio] failed to open editor:', err);
-      new Notice('Drawio: failed to open editor — see console (Ctrl+Shift+I)');
-      this.contentEl.createDiv({ cls: 'drawio-error', text: String(err) });
+      const msg = err instanceof OfflineEditorNotInstalledError
+        ? err.message
+        : 'Drawio: failed to open editor — see console (Ctrl+Shift+I)';
+      new Notice(msg, 8000);
+      this.contentEl.createDiv({
+        cls: 'drawio-error',
+        text: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/src/file/DrawioFileView.ts
+++ b/src/file/DrawioFileView.ts
@@ -65,7 +65,10 @@ export class DrawioFileView extends TextFileView {
     this.editor = new DrawioEditor(c, source, this.plugin.editorDeps());
     this.editor.mount().catch((err) => {
       console.error('[drawio] file-view editor failed to mount', err);
-      c.createDiv({ cls: 'drawio-error', text: String(err) });
+      c.createDiv({
+        cls: 'drawio-error',
+        text: err instanceof Error ? err.message : String(err),
+      });
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { Plugin, FileSystemAdapter, Notice, Platform } from 'obsidian';
+import { Plugin, FileSystemAdapter, Platform } from 'obsidian';
+import { OfflineEditorNotInstalledError } from './model/errors';
 import { DrawioSettings, DEFAULT_SETTINGS } from './settings';
 import type { ServerManager } from './server/ServerManager';
 import { DrawioModal } from './editor/DrawioModal';
@@ -10,8 +11,6 @@ import { DRAWIO_VIEW_TYPE, DRAWIO_FILE_EXT, ONLINE_DRAWIO_URL } from './constant
 export default class DrawioPlugin extends Plugin {
   settings!: DrawioSettings;
   server: ServerManager | null = null;
-  /** Show the "offline editor missing, using online" notice only once. */
-  private warnedOfflineFallback = false;
 
   async onload() {
     await this.loadSettings();
@@ -63,30 +62,44 @@ export default class DrawioPlugin extends Plugin {
     throw new Error('Drawio plugin requires a desktop (FileSystem) vault');
   }
 
+  /** Whether the bundled offline webapp is installed (same criterion the local
+   * server relies on: webapp/index.html exists). Desktop-only caller; node
+   * modules are imported dynamically per the mobile-safety rule. */
+  async isWebappInstalled(): Promise<boolean> {
+    const path = await import('node:path');
+    const fs = await import('node:fs');
+    return fs.existsSync(path.join(await this.pluginDir(), 'webapp', 'index.html'));
+  }
+
+  /** The installed webapp's pinned version (from the DRAWIO_VERSION file the
+   * installer/fetch script writes), or null when absent — manual installs may
+   * not carry the file, which is fine. Desktop-only caller. */
+  async installedWebappVersion(): Promise<string | null> {
+    try {
+      const path = await import('node:path');
+      const fs = await import('node:fs');
+      const raw = fs.readFileSync(
+        path.join(await this.pluginDir(), 'webapp', 'DRAWIO_VERSION'), 'utf8');
+      return raw.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
   async resolveBaseUrl(): Promise<string> {
     const mode = this.settings.drawioMode;
     if (mode === 'custom' && this.settings.customDrawioUrl) {
       return this.settings.customDrawioUrl;
     }
     if (mode === 'offline') {
-      const path = await import('node:path');
-      const fs = await import('node:fs');
-      const indexPath = path.join(await this.pluginDir(), 'webapp', 'index.html');
-      if (fs.existsSync(indexPath)) {
-        const port = await this.server!.ensureStarted();
-        this.server!.touch();
-        return `http://127.0.0.1:${port}/index.html`;
+      // No fallback: offline means offline. The entry points surface this
+      // error's message, which points at the settings-tab installer.
+      if (!(await this.isWebappInstalled())) {
+        throw new OfflineEditorNotInstalledError();
       }
-      // No bundled webapp (e.g. a community-store install, where the ~145 MB
-      // webapp can't ship). Fall back to the online editor so it still works.
-      if (!this.warnedOfflineFallback) {
-        this.warnedOfflineFallback = true;
-        new Notice(
-          'Drawio: the bundled offline editor isn\'t installed — using the online editor (diagrams.net). See the README to enable the offline editor.',
-          8000,
-        );
-      }
-      return ONLINE_DRAWIO_URL;
+      const port = await this.server!.ensureStarted();
+      this.server!.touch();
+      return `http://127.0.0.1:${port}/index.html`;
     }
     // 'online' (and 'custom' with no URL set) → the hosted diagrams.net embed.
     return ONLINE_DRAWIO_URL;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Plugin, FileSystemAdapter, Platform } from 'obsidian';
 import { OfflineEditorNotInstalledError } from './model/errors';
+import { InstallStatus } from './model/installStatus';
 import { DrawioSettings, DEFAULT_SETTINGS } from './settings';
 import type { ServerManager } from './server/ServerManager';
 import { DrawioModal } from './editor/DrawioModal';
@@ -11,6 +12,9 @@ import { DRAWIO_VIEW_TYPE, DRAWIO_FILE_EXT, ONLINE_DRAWIO_URL } from './constant
 export default class DrawioPlugin extends Plugin {
   settings!: DrawioSettings;
   server: ServerManager | null = null;
+  /** Offline-webapp install state — on the plugin (not the settings tab) so a
+   * mid-install settings re-render can re-attach to the running install. */
+  webappInstallStatus = new InstallStatus();
 
   async onload() {
     await this.loadSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,10 +53,11 @@ export default class DrawioPlugin extends Plugin {
     this.server?.stop();
   }
 
-  /** Absolute path to this plugin's folder on disk. Desktop-only caller
-   * (resolveBaseUrl's offline branch) — dynamically imports node:path so this
-   * method's own presence in main.ts never triggers an eager require() on
-   * mobile. */
+  /** Absolute path to this plugin's folder on disk. Desktop-only callers
+   * (resolveBaseUrl's offline branch, isWebappInstalled(),
+   * installedWebappVersion(), and the settings tab's install flow) —
+   * dynamically imports node:path so this method's own presence in main.ts
+   * never triggers an eager require() on mobile. */
   async pluginDir(): Promise<string> {
     const adapter = this.app.vault.adapter;
     if (adapter instanceof FileSystemAdapter) {

--- a/src/model/errors.ts
+++ b/src/model/errors.ts
@@ -1,0 +1,13 @@
+/** Thrown by resolveBaseUrl() when the editor source is Offline but the bundled
+ * webapp isn't installed. The message is user-facing: both editor entry points
+ * (DrawioModal, DrawioFileView) display it verbatim. There is deliberately no
+ * automatic online fallback — offline means offline. */
+export class OfflineEditorNotInstalledError extends Error {
+  constructor() {
+    super(
+      "The offline drawio editor isn't installed. Install it in the Drawio plugin " +
+      'settings, or switch the editor source to Online.',
+    );
+    this.name = 'OfflineEditorNotInstalledError';
+  }
+}

--- a/src/model/installStatus.ts
+++ b/src/model/installStatus.ts
@@ -1,0 +1,6 @@
+/** Progress events emitted by the offline-webapp installer. Download progress
+ * is per-chunk; extraction is a single coarse phase (fflate's unzipSync is
+ * synchronous — deliberately no finer granularity, per the design spec). */
+export type InstallProgress =
+  | { phase: 'download'; received: number; total: number | null }
+  | { phase: 'extract' };

--- a/src/model/installStatus.ts
+++ b/src/model/installStatus.ts
@@ -4,3 +4,33 @@
 export type InstallProgress =
   | { phase: 'download'; received: number; total: number | null }
   | { phase: 'extract' };
+
+/** UI-facing install state, held on the plugin instance so it outlives
+ * settings-tab re-renders (display() rebuilds the whole pane at any time). */
+export type WebappInstallState =
+  | { status: 'idle' }
+  | { status: 'installing'; progressText: string }
+  | { status: 'error'; message: string };
+
+/** Single-listener state holder: the settings row re-subscribes on every
+ * render, and only one settings pane exists, so last-subscriber-wins is
+ * exactly the right semantics. */
+export class InstallStatus {
+  state: WebappInstallState = { status: 'idle' };
+  private listener: ((s: WebappInstallState) => void) | null = null;
+
+  set(state: WebappInstallState): void {
+    this.state = state;
+    this.listener?.(state);
+  }
+
+  subscribe(cb: (s: WebappInstallState) => void): void {
+    this.listener = cb;
+  }
+}
+
+export function formatInstallProgress(p: InstallProgress): string {
+  if (p.phase === 'extract') return 'Extracting…';
+  if (p.total) return `Downloading… ${Math.floor((p.received / p.total) * 100)}%`;
+  return `Downloading… ${(p.received / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -168,6 +168,7 @@ export class DrawioSettingTab extends PluginSettingTab {
 
     const status = this.plugin.webappInstallStatus;
     const refresh = async (state: WebappInstallState) => {
+      button.removeCta();
       if (state.status === 'installing') {
         setting.setDesc(state.progressText);
         button.setButtonText('Installing…').setDisabled(true);

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,5 +1,6 @@
 import { App, ButtonComponent, Platform, PluginSettingTab, Setting } from 'obsidian';
 import type DrawioPlugin from './main';
+import { DRAWIO_VERSION } from './constants';
 import { formatInstallProgress, type WebappInstallState } from './model/installStatus';
 import type { DrawioMode, NewDiagramLocation, PreviewAlignment, PreviewClickAction } from './settings';
 
@@ -186,8 +187,19 @@ export class DrawioSettingTab extends PluginSettingTab {
       if (status.state.status !== 'idle') return; // an install started meanwhile
       if (installed) {
         const version = await this.plugin.installedWebappVersion();
-        setting.setDesc(version ? `Installed (drawio ${version}).` : 'Installed.');
-        button.setButtonText('Reinstall').setDisabled(false);
+        if (version && version !== DRAWIO_VERSION) {
+          // A plugin update bumped the pinned drawio version; previews already
+          // use the new bundled viewer, so nudge the webapp to match. Updating
+          // is the same pipeline as installing (always installs the pin).
+          setting.setDesc(
+            `Installed (drawio ${version}). Update available: this plugin version ` +
+            `bundles drawio ${DRAWIO_VERSION}.`,
+          );
+          button.setButtonText('Update').setCta().setDisabled(false);
+        } else {
+          setting.setDesc(version ? `Installed (drawio ${version}).` : 'Installed.');
+          button.setButtonText('Reinstall').setDisabled(false);
+        }
       } else {
         setting.setDesc(
           'Not installed. Installing downloads ~53 MB from GitHub (one time, needs network); ' +

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,5 +1,6 @@
-import { App, Platform, PluginSettingTab, Setting } from 'obsidian';
+import { App, ButtonComponent, Platform, PluginSettingTab, Setting } from 'obsidian';
 import type DrawioPlugin from './main';
+import { formatInstallProgress, type WebappInstallState } from './model/installStatus';
 import type { DrawioMode, NewDiagramLocation, PreviewAlignment, PreviewClickAction } from './settings';
 
 /**
@@ -27,8 +28,8 @@ export class DrawioSettingTab extends PluginSettingTab {
         .setName('Editor source')
         .setDesc(
           'Offline (default) uses the bundled editor served locally — fully offline, no network. ' +
-          'Online loads the editor from diagrams.net. Or point at a custom embed URL. If Offline is ' +
-          "selected but the bundled webapp isn't installed, the online editor is used automatically.",
+          'Online loads the editor from diagrams.net. Or point at a custom embed URL. The offline ' +
+          'editor requires a one-time install — see below when Offline is selected.',
         )
         .addDropdown((d) => d
           .addOption('online', 'Online (diagrams.net)')
@@ -54,6 +55,11 @@ export class DrawioSettingTab extends PluginSettingTab {
             .setPlaceholder('https://embed.diagrams.net/')
             .setValue(s.customDrawioUrl)
             .onChange((v) => { s.customDrawioUrl = v; save(); }));
+      }
+
+      // Offline-editor install status + one-click installer.
+      if (s.drawioMode === 'offline') {
+        this.renderOfflineEditorStatus(containerEl);
       }
 
       new Setting(containerEl)
@@ -145,6 +151,70 @@ export class DrawioSettingTab extends PluginSettingTab {
               this.plugin.updateServerIdleTimeout();
             });
         });
+    }
+  }
+
+  /** Status row for the bundled offline editor: detection is async (disk
+   * check), so the row renders a checking state and fills itself in; while an
+   * install runs, the row re-subscribes to the plugin-held status each render
+   * so progress survives full display() re-renders. */
+  private renderOfflineEditorStatus(containerEl: HTMLElement): void {
+    const setting = new Setting(containerEl).setName('Offline editor');
+    let button!: ButtonComponent;
+    setting.addButton((b) => {
+      button = b;
+      b.onClick(() => { void this.startInstall(); });
+    });
+
+    const status = this.plugin.webappInstallStatus;
+    const refresh = async (state: WebappInstallState) => {
+      if (state.status === 'installing') {
+        setting.setDesc(state.progressText);
+        button.setButtonText('Installing…').setDisabled(true);
+        return;
+      }
+      if (state.status === 'error') {
+        setting.setDesc(`Install failed: ${state.message}`);
+        button.setButtonText('Retry').setDisabled(false);
+        return;
+      }
+      // idle → check the disk.
+      setting.setDesc('Checking installation…');
+      button.setButtonText('Install').setDisabled(true);
+      const installed = await this.plugin.isWebappInstalled();
+      if (status.state.status !== 'idle') return; // an install started meanwhile
+      if (installed) {
+        const version = await this.plugin.installedWebappVersion();
+        setting.setDesc(version ? `Installed (drawio ${version}).` : 'Installed.');
+        button.setButtonText('Reinstall').setDisabled(false);
+      } else {
+        setting.setDesc(
+          'Not installed. Installing downloads ~53 MB from GitHub (one time, needs network); ' +
+          'editing is fully offline afterwards. Reinstalling interrupts any open offline editor.',
+        );
+        button.setButtonText('Install').setCta().setDisabled(false);
+      }
+    };
+    status.subscribe((state) => { void refresh(state); });
+    void refresh(status.state);
+  }
+
+  /** Runs the installer, publishing progress through the plugin-held status.
+   * Stops the local server first: on Windows an open handle inside webapp/
+   * would make the atomic swap fail. */
+  private async startInstall(): Promise<void> {
+    const status = this.plugin.webappInstallStatus;
+    if (status.state.status === 'installing') return;
+    this.plugin.server?.stop();
+    status.set({ status: 'installing', progressText: 'Starting download…' });
+    try {
+      const { installWebapp } = await import('./desktop/webappInstaller');
+      await installWebapp(await this.plugin.pluginDir(), (p) => {
+        status.set({ status: 'installing', progressText: formatInstallProgress(p) });
+      });
+      status.set({ status: 'idle' });
+    } catch (e) {
+      status.set({ status: 'error', message: e instanceof Error ? e.message : String(e) });
     }
   }
 }

--- a/tests/drawioVersionSync.test.ts
+++ b/tests/drawioVersionSync.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { DRAWIO_VERSION, DRAWIO_WAR_URL } from '../src/constants';
+
+// The runtime installer (src/desktop/webappInstaller.ts) and the build-time
+// fetch script must install the exact same drawio version, or the bundled
+// viewer.min.txt and the installed webapp drift apart.
+describe('drawio version pinning', () => {
+  it('matches the version pinned in scripts/fetch-drawio.mjs', () => {
+    const script = readFileSync('scripts/fetch-drawio.mjs', 'utf8');
+    const m = script.match(/DRAWIO_VERSION = '([^']+)'/);
+    expect(m?.[1]).toBe(DRAWIO_VERSION);
+  });
+
+  it('builds the war URL from the pinned version', () => {
+    expect(DRAWIO_WAR_URL).toBe(
+      `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`,
+    );
+  });
+});

--- a/tests/installStatus.test.ts
+++ b/tests/installStatus.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InstallStatus, formatInstallProgress } from '../src/model/installStatus';
+
+describe('InstallStatus', () => {
+  it('notifies the current subscriber on set', () => {
+    const s = new InstallStatus();
+    const cb = vi.fn();
+    s.subscribe(cb);
+    s.set({ status: 'installing', progressText: 'Downloading… 10%' });
+    expect(s.state).toEqual({ status: 'installing', progressText: 'Downloading… 10%' });
+    expect(cb).toHaveBeenCalledWith({ status: 'installing', progressText: 'Downloading… 10%' });
+  });
+
+  it('replaces the previous subscriber (settings re-render)', () => {
+    const s = new InstallStatus();
+    const first = vi.fn();
+    const second = vi.fn();
+    s.subscribe(first);
+    s.subscribe(second);
+    s.set({ status: 'idle' });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalled();
+  });
+});
+
+describe('formatInstallProgress', () => {
+  it('formats download with a known total as a percentage', () => {
+    expect(formatInstallProgress({ phase: 'download', received: 26_500_000, total: 53_000_000 }))
+      .toBe('Downloading… 50%');
+  });
+
+  it('formats download without a total as received MB', () => {
+    expect(formatInstallProgress({ phase: 'download', received: 5 * 1024 * 1024, total: null }))
+      .toBe('Downloading… 5.0 MB');
+  });
+
+  it('formats extraction', () => {
+    expect(formatInstallProgress({ phase: 'extract' })).toBe('Extracting…');
+  });
+});

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -82,7 +82,8 @@ class TextComponent {
 export class ButtonComponent {
   buttonEl: HTMLButtonElement = document.createElement('button');
   setButtonText(t: string): this { this.buttonEl.textContent = t; return this; }
-  setCta(): this { return this; }
+  setCta(): this { this.buttonEl.classList.add('mod-cta'); return this; }
+  removeCta(): this { this.buttonEl.classList.remove('mod-cta'); return this; }
   setDisabled(d: boolean): this { this.buttonEl.disabled = d; return this; }
   onClick(cb: (evt: MouseEvent) => unknown): this {
     this.buttonEl.addEventListener('click', () => { void cb(new MouseEvent('click')); });

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -79,8 +79,20 @@ class TextComponent {
   onChange(_cb: (value: string) => void): this { return this; }
 }
 
+export class ButtonComponent {
+  buttonEl: HTMLButtonElement = document.createElement('button');
+  setButtonText(t: string): this { this.buttonEl.textContent = t; return this; }
+  setCta(): this { return this; }
+  setDisabled(d: boolean): this { this.buttonEl.disabled = d; return this; }
+  onClick(cb: (evt: MouseEvent) => unknown): this {
+    this.buttonEl.addEventListener('click', () => { void cb(new MouseEvent('click')); });
+    return this;
+  }
+}
+
 export class Setting {
   settingEl: HTMLElement;
+  descEl: HTMLElement;
   private nameEl: HTMLElement;
   constructor(containerEl: HTMLElement) {
     this.settingEl = document.createElement('div');
@@ -88,13 +100,22 @@ export class Setting {
     this.nameEl = document.createElement('div');
     this.nameEl.className = 'setting-item-name';
     this.settingEl.appendChild(this.nameEl);
+    this.descEl = document.createElement('div');
+    this.descEl.className = 'setting-item-description';
+    this.settingEl.appendChild(this.descEl);
     containerEl.appendChild(this.settingEl);
   }
   setName(name: string): this { this.nameEl.textContent = name; return this; }
-  setDesc(_desc: string): this { return this; }
+  setDesc(desc: string): this { this.descEl.textContent = desc; return this; }
   addDropdown(cb: (d: DropdownComponent) => unknown): this { cb(new DropdownComponent()); return this; }
   addToggle(cb: (t: ToggleComponent) => unknown): this { cb(new ToggleComponent()); return this; }
   addText(cb: (t: TextComponent) => unknown): this { cb(new TextComponent()); return this; }
+  addButton(cb: (b: ButtonComponent) => unknown): this {
+    const b = new ButtonComponent();
+    this.settingEl.appendChild(b.buttonEl);
+    cb(b);
+    return this;
+  }
 }
 
 export class MarkdownRenderChild {

--- a/tests/registerDesktopFeatures.test.ts
+++ b/tests/registerDesktopFeatures.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { FileSystemAdapter } from 'obsidian';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('obsidian', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('obsidian')>();
+  return { ...orig, Notice: vi.fn() };
+});
+
+import { FileSystemAdapter, Notice } from 'obsidian';
 import { registerDesktopFeatures } from '../src/desktop/registerDesktopFeatures';
 import type DrawioPlugin from '../src/main';
 
@@ -15,17 +21,23 @@ function fakePlugin() {
       workspace: { on: workspaceOn },
     },
     manifest: { dir: 'drawio-editor' },
-    settings: { serverPortMin: 3000, serverPortMax: 3999, serverIdleTimeout: 300 },
+    settings: {
+      serverPortMin: 3000, serverPortMax: 3999, serverIdleTimeout: 300,
+      drawioMode: 'offline',
+    },
     server: null as unknown,
     register: vi.fn(),
     addCommand: vi.fn(),
     addRibbonIcon: vi.fn(),
     registerEvent: vi.fn(),
+    isWebappInstalled: vi.fn(async () => true),
   };
   return { plugin: raw as unknown as DrawioPlugin, raw, workspaceOn };
 }
 
 describe('registerDesktopFeatures', () => {
+  beforeEach(() => { vi.mocked(Notice).mockClear(); });
+
   it('builds and assigns a ServerManager to plugin.server, and registers its teardown', async () => {
     const { plugin, raw } = fakePlugin();
     await registerDesktopFeatures(plugin);
@@ -60,5 +72,28 @@ describe('registerDesktopFeatures', () => {
     const { plugin, raw } = fakePlugin();
     (raw.app as { vault: { adapter: unknown } }).vault.adapter = {};
     await expect(registerDesktopFeatures(plugin)).rejects.toThrow(/desktop \(FileSystem\) vault/);
+  });
+
+  it('shows a notice when offline mode is set but the webapp is missing', async () => {
+    const { plugin, raw } = fakePlugin();
+    raw.isWebappInstalled = vi.fn(async () => false);
+    await registerDesktopFeatures(plugin);
+    expect(Notice).toHaveBeenCalledWith(
+      expect.stringContaining('offline editor'), expect.any(Number),
+    );
+  });
+
+  it('stays silent when the webapp is installed', async () => {
+    const { plugin } = fakePlugin();
+    await registerDesktopFeatures(plugin);
+    expect(Notice).not.toHaveBeenCalled();
+  });
+
+  it('stays silent in online mode even without the webapp', async () => {
+    const { plugin, raw } = fakePlugin();
+    raw.settings.drawioMode = 'online';
+    raw.isWebappInstalled = vi.fn(async () => false);
+    await registerDesktopFeatures(plugin);
+    expect(Notice).not.toHaveBeenCalled();
   });
 });

--- a/tests/resolveBaseUrl.test.ts
+++ b/tests/resolveBaseUrl.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import DrawioPlugin from '../src/main';
+import { OfflineEditorNotInstalledError } from '../src/model/errors';
+import { ONLINE_DRAWIO_URL } from '../src/constants';
+
+// resolveBaseUrl/isWebappInstalled are instance methods with no constructor
+// dependencies beyond the fields they read, so they are tested via
+// prototype.call on a minimal fake (same pattern as other suites' fakePlugin).
+// The cast keeps strictBindCallApply satisfied.
+const proto = DrawioPlugin.prototype;
+const asPlugin = (o: object) => o as unknown as DrawioPlugin;
+
+describe('resolveBaseUrl', () => {
+  it('throws OfflineEditorNotInstalledError in offline mode without the webapp', async () => {
+    const fake = asPlugin({
+      settings: { drawioMode: 'offline', customDrawioUrl: '' },
+      isWebappInstalled: async () => false,
+    });
+    await expect(proto.resolveBaseUrl.call(fake)).rejects.toBeInstanceOf(
+      OfflineEditorNotInstalledError,
+    );
+  });
+
+  it('serves from the local server in offline mode when installed', async () => {
+    const touch = vi.fn();
+    const fake = asPlugin({
+      settings: { drawioMode: 'offline', customDrawioUrl: '' },
+      isWebappInstalled: async () => true,
+      server: { ensureStarted: async () => 3456, touch },
+    });
+    await expect(proto.resolveBaseUrl.call(fake)).resolves.toBe(
+      'http://127.0.0.1:3456/index.html',
+    );
+    expect(touch).toHaveBeenCalled();
+  });
+
+  it('returns the online URL in online mode', async () => {
+    const fake = asPlugin({ settings: { drawioMode: 'online', customDrawioUrl: '' } });
+    await expect(proto.resolveBaseUrl.call(fake)).resolves.toBe(ONLINE_DRAWIO_URL);
+  });
+});
+
+describe('isWebappInstalled / installedWebappVersion', () => {
+  it('reflects webapp/index.html presence and reads DRAWIO_VERSION', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'drawio-detect-'));
+    try {
+      const fake = asPlugin({ pluginDir: async () => dir });
+      expect(await proto.isWebappInstalled.call(fake)).toBe(false);
+      expect(await proto.installedWebappVersion.call(fake)).toBeNull();
+
+      mkdirSync(join(dir, 'webapp'), { recursive: true });
+      writeFileSync(join(dir, 'webapp', 'index.html'), '<html></html>');
+      expect(await proto.isWebappInstalled.call(fake)).toBe(true);
+      // Manually-installed webapps may lack the version file — that is not an error.
+      expect(await proto.installedWebappVersion.call(fake)).toBeNull();
+
+      writeFileSync(join(dir, 'webapp', 'DRAWIO_VERSION'), 'v30.0.4\n');
+      expect(await proto.installedWebappVersion.call(fake)).toBe('v30.0.4');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/settingsTab.test.ts
+++ b/tests/settingsTab.test.ts
@@ -113,4 +113,21 @@ describe('offline editor status row', () => {
     tab.display();
     expect(statusRow(tab.containerEl)).toBeNull();
   });
+
+  it('drops the CTA styling once the button leaves the Install state', async () => {
+    Platform.isDesktopApp = true;
+    const plugin = fakePlugin();
+    const tab = new DrawioSettingTab({} as never, plugin);
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    const button = row.querySelector<HTMLButtonElement>('button')!;
+    await vi.waitFor(() => {
+      expect(button.textContent).toBe('Install');
+      expect(button.classList.contains('mod-cta')).toBe(true);
+    });
+    (plugin as unknown as { webappInstallStatus: InstallStatus }).webappInstallStatus
+      .set({ status: 'installing', progressText: 'Downloading… 10%' });
+    expect(button.textContent).toBe('Installing…');
+    expect(button.classList.contains('mod-cta')).toBe(false);
+  });
 });

--- a/tests/settingsTab.test.ts
+++ b/tests/settingsTab.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Platform } from 'obsidian';
 import { DrawioSettingTab } from '../src/settingsTab';
 import { DEFAULT_SETTINGS } from '../src/settings';
+import { DRAWIO_VERSION } from '../src/constants';
 import { InstallStatus } from '../src/model/installStatus';
 import type DrawioPlugin from '../src/main';
 
@@ -90,6 +91,40 @@ describe('offline editor status row', () => {
     await vi.waitFor(() => {
       expect(row.querySelector('button')?.textContent).toBe('Reinstall');
       expect(row.querySelector('.setting-item-description')?.textContent).toContain('v30.0.4');
+    });
+  });
+
+  it('offers Update (with CTA) when the installed version differs from the pinned one', async () => {
+    Platform.isDesktopApp = true;
+    const tab = new DrawioSettingTab({} as never, fakePlugin({
+      isWebappInstalled: async () => true,
+      installedWebappVersion: async () => 'v29.0.0',
+    }));
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    await vi.waitFor(() => {
+      const button = row.querySelector<HTMLButtonElement>('button')!;
+      expect(button.textContent).toBe('Update');
+      expect(button.classList.contains('mod-cta')).toBe(true);
+      const desc = row.querySelector('.setting-item-description')?.textContent ?? '';
+      expect(desc).toContain('v29.0.0');
+      expect(desc).toContain(DRAWIO_VERSION);
+    });
+  });
+
+  it('keeps Reinstall (no update prompt) when the installed version is unknown', async () => {
+    Platform.isDesktopApp = true;
+    const tab = new DrawioSettingTab({} as never, fakePlugin({
+      isWebappInstalled: async () => true,
+      installedWebappVersion: async () => null,
+    }));
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    await vi.waitFor(() => {
+      const button = row.querySelector<HTMLButtonElement>('button')!;
+      expect(button.textContent).toBe('Reinstall');
+      expect(button.classList.contains('mod-cta')).toBe(false);
+      expect(row.querySelector('.setting-item-description')?.textContent).toBe('Installed.');
     });
   });
 

--- a/tests/settingsTab.test.ts
+++ b/tests/settingsTab.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Platform } from 'obsidian';
 import { DrawioSettingTab } from '../src/settingsTab';
 import { DEFAULT_SETTINGS } from '../src/settings';
+import { InstallStatus } from '../src/model/installStatus';
 import type DrawioPlugin from '../src/main';
 
-function fakePlugin(): DrawioPlugin {
+function fakePlugin(overrides: Record<string, unknown> = {}): DrawioPlugin {
   return {
     settings: { ...DEFAULT_SETTINGS },
     saveSettings: async () => {},
     updateServerIdleTimeout: () => {},
+    webappInstallStatus: new InstallStatus(),
+    isWebappInstalled: async () => false,
+    installedWebappVersion: async () => null,
+    server: null,
+    ...overrides,
   } as unknown as DrawioPlugin;
 }
 
@@ -48,5 +54,63 @@ describe('DrawioSettingTab', () => {
     expect(names).not.toContain('Preview click action');
     expect(names).toContain('Preview alignment');
     expect(names).toContain('Follow Obsidian theme');
+  });
+});
+
+describe('offline editor status row', () => {
+  const originalIsDesktopApp = Platform.isDesktopApp;
+  afterEach(() => { Platform.isDesktopApp = originalIsDesktopApp; });
+
+  function statusRow(containerEl: HTMLElement): HTMLElement | null {
+    return Array.from(containerEl.querySelectorAll('.setting-item')).find((el) =>
+      el.querySelector('.setting-item-name')?.textContent === 'Offline editor',
+    ) as HTMLElement ?? null;
+  }
+
+  it('is shown in offline mode and offers Install when not installed', async () => {
+    Platform.isDesktopApp = true;
+    const tab = new DrawioSettingTab({} as never, fakePlugin());
+    tab.display();
+    const row = statusRow(tab.containerEl);
+    expect(row).not.toBeNull();
+    await vi.waitFor(() => {
+      expect(row!.querySelector('button')?.textContent).toBe('Install');
+      expect(row!.querySelector('.setting-item-description')?.textContent).toContain('Not installed');
+    });
+  });
+
+  it('offers Reinstall and shows the version when installed', async () => {
+    Platform.isDesktopApp = true;
+    const tab = new DrawioSettingTab({} as never, fakePlugin({
+      isWebappInstalled: async () => true,
+      installedWebappVersion: async () => 'v30.0.4',
+    }));
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    await vi.waitFor(() => {
+      expect(row.querySelector('button')?.textContent).toBe('Reinstall');
+      expect(row.querySelector('.setting-item-description')?.textContent).toContain('v30.0.4');
+    });
+  });
+
+  it('renders live progress while an install is running', async () => {
+    Platform.isDesktopApp = true;
+    const plugin = fakePlugin();
+    (plugin as unknown as { webappInstallStatus: InstallStatus }).webappInstallStatus
+      .set({ status: 'installing', progressText: 'Downloading… 42%' });
+    const tab = new DrawioSettingTab({} as never, plugin);
+    tab.display();
+    const row = statusRow(tab.containerEl)!;
+    expect(row.querySelector('.setting-item-description')?.textContent).toBe('Downloading… 42%');
+    expect(row.querySelector<HTMLButtonElement>('button')?.disabled).toBe(true);
+  });
+
+  it('is absent in online mode', () => {
+    Platform.isDesktopApp = true;
+    const plugin = fakePlugin();
+    (plugin as unknown as { settings: { drawioMode: string } }).settings.drawioMode = 'online';
+    const tab = new DrawioSettingTab({} as never, plugin);
+    tab.display();
+    expect(statusRow(tab.containerEl)).toBeNull();
   });
 });

--- a/tests/webappInstaller.test.ts
+++ b/tests/webappInstaller.test.ts
@@ -3,7 +3,7 @@ import { zipSync, strToU8 } from 'fflate';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { installFromWar } from '../src/desktop/webappInstaller';
+import { installFromWar, swapWebappIntoPlace } from '../src/desktop/webappInstaller';
 import { DRAWIO_VERSION } from '../src/constants';
 
 function makeWar(entries: Record<string, Uint8Array> = {}): Uint8Array {
@@ -65,5 +65,27 @@ describe('installFromWar', () => {
     expect(() => installFromWar(evil, dir)).toThrow(/[Uu]nsafe zip entry/);
     expect(existsSync(join(dir, 'evil.txt'))).toBe(false);
     expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+});
+
+describe('swapWebappIntoPlace', () => {
+  it('rolls the old webapp back when the staging rename fails', () => {
+    mkdirSync(join(dir, 'webapp'), { recursive: true });
+    writeFileSync(join(dir, 'webapp', 'marker.txt'), 'original install');
+    // No webapp.installing/ created, so the staging rename throws ENOENT
+    // after the old webapp has already been renamed aside.
+    expect(() => swapWebappIntoPlace(dir)).toThrow();
+    expect(readFileSync(join(dir, 'webapp', 'marker.txt'), 'utf8')).toBe('original install');
+    expect(existsSync(join(dir, 'webapp.old'))).toBe(false);
+  });
+
+  it('clears a leftover webapp.old from a previous crash', () => {
+    mkdirSync(join(dir, 'webapp.old'), { recursive: true });
+    writeFileSync(join(dir, 'webapp.old', 'junk.txt'), 'junk');
+    mkdirSync(join(dir, 'webapp.installing'), { recursive: true });
+    writeFileSync(join(dir, 'webapp.installing', 'index.html'), 'new install');
+    swapWebappIntoPlace(dir);
+    expect(existsSync(join(dir, 'webapp.old'))).toBe(false);
+    expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('new install');
   });
 });

--- a/tests/webappInstaller.test.ts
+++ b/tests/webappInstaller.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { zipSync, strToU8 } from 'fflate';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { installFromWar } from '../src/desktop/webappInstaller';
+import { DRAWIO_VERSION } from '../src/constants';
+
+function makeWar(entries: Record<string, Uint8Array> = {}): Uint8Array {
+  return zipSync({
+    'index.html': strToU8('<html>drawio</html>'),
+    'js/viewer.min.js': strToU8('// viewer'),
+    'WEB-INF/web.xml': strToU8('<web-app/>'),
+    'META-INF/MANIFEST.MF': strToU8('Manifest-Version: 1.0'),
+    ...entries,
+  });
+}
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'drawio-install-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('installFromWar', () => {
+  it('extracts the webapp, skipping WEB-INF/META-INF, and writes DRAWIO_VERSION', () => {
+    installFromWar(makeWar(), dir);
+    expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('<html>drawio</html>');
+    expect(existsSync(join(dir, 'webapp', 'js', 'viewer.min.js'))).toBe(true);
+    expect(existsSync(join(dir, 'webapp', 'WEB-INF'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp', 'META-INF'))).toBe(false);
+    expect(readFileSync(join(dir, 'webapp', 'DRAWIO_VERSION'), 'utf8').trim()).toBe(DRAWIO_VERSION);
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+
+  it('replaces an existing webapp atomically', () => {
+    mkdirSync(join(dir, 'webapp'), { recursive: true });
+    writeFileSync(join(dir, 'webapp', 'stale.txt'), 'old');
+    installFromWar(makeWar(), dir);
+    expect(existsSync(join(dir, 'webapp', 'stale.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
+  });
+
+  it('cleans leftover webapp.installing from a previously interrupted run', () => {
+    mkdirSync(join(dir, 'webapp.installing'), { recursive: true });
+    writeFileSync(join(dir, 'webapp.installing', 'junk.txt'), 'junk');
+    installFromWar(makeWar(), dir);
+    expect(existsSync(join(dir, 'webapp', 'junk.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
+  });
+
+  it('rejects an archive missing required files, keeping the old webapp intact', () => {
+    mkdirSync(join(dir, 'webapp'), { recursive: true });
+    writeFileSync(join(dir, 'webapp', 'index.html'), 'previous install');
+    const bad = zipSync({ 'js/viewer.min.js': strToU8('// viewer only') });
+    expect(() => installFromWar(bad, dir)).toThrow(/index\.html/);
+    // Old install untouched, staging cleaned up.
+    expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('previous install');
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+
+  it('rejects zip entries that escape the target directory (zip-slip)', () => {
+    // If fflate's zipSync ever refuses to create '../' entry names, keep the
+    // guard in the implementation and adapt this test to call the exported
+    // path check directly instead of deleting the test.
+    const evil = makeWar({ '../evil.txt': strToU8('escape') });
+    expect(() => installFromWar(evil, dir)).toThrow(/[Uu]nsafe zip entry/);
+    expect(existsSync(join(dir, 'evil.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+});

--- a/tests/webappInstaller.test.ts
+++ b/tests/webappInstaller.test.ts
@@ -37,6 +37,7 @@ describe('installFromWar', () => {
     installFromWar(makeWar(), dir);
     expect(existsSync(join(dir, 'webapp', 'stale.txt'))).toBe(false);
     expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
+    expect(existsSync(join(dir, 'webapp.old'))).toBe(false);
   });
 
   it('cleans leftover webapp.installing from a previously interrupted run', () => {


### PR DESCRIPTION
## Summary

Removes the silent offline→online editor fallback and replaces it with explicit detection plus a one-click installer in the settings tab:

- **`resolveBaseUrl()` no longer falls back**: in Offline mode without the webapp it throws a typed `OfflineEditorNotInstalledError` whose message (install in settings, or switch to Online) is surfaced by both editor entry points.
- **Settings tab, Offline mode**: an "Offline editor" status row — Checking → Install (CTA) / Installing… (live progress; download % then Extracting…) / Installed (drawio v30.0.4, version read from disk) + Reinstall / Retry on failure. Install state lives on the plugin instance, so a mid-install settings re-render re-attaches to running progress.
- **Installer** (`src/desktop/webappInstaller.ts`): downloads the pinned `draw.war` (~53 MB, v30.0.4 — same pin as `scripts/fetch-drawio.mjs`, drift-guarded by a test) via `node:https` with redirect following and a content-length integrity check, extracts with `fflate` (devDependency, inlined by esbuild) skipping `WEB-INF`/`META-INF`, zip-slip guard, validates, then swaps via **rename-aside** (`webapp` → `webapp.old`, staging → `webapp`, rollback on failure) so a failed install can never damage an existing one. The local server is stopped before installing (Windows file locks).
- **Load-time notice** when Offline mode is selected but the webapp is missing.
- **Update check**: when the installed webapp's version differs from the plugin's pinned `DRAWIO_VERSION` (e.g. after a plugin update bumps the pin), the settings row shows **Update** (CTA) with both versions — same install pipeline, keeping the webapp in lockstep with the bundled preview viewer.
- Default mode stays **Offline** (user decision).

## ⚠️ Behavior change for release notes

Store users on the default Offline mode who never touched settings were silently using the online editor. After this change they get a load-time notice and an install prompt instead. Call this out prominently in the next release's notes.

## Merge-time note

This branch is based on `origin/main` (40ed619). Local `main` carries two unpushed merges (page-flip isolation, preview-edit-hint) whose test files don't exist on this branch. After merging, re-run the full suite so those viewer-behavior tests run against these changes.

## Verification

- 29 test files / 174 tests pass on-branch (after `npm run fetch-drawio`); production build clean (guard plugins pass).
- Feasibility check: the real ~53 MB `draw.war` was downloaded and installed through the production `installWebapp()` code path (redirects, content-length, extraction, swap all exercised) — ended `FEASIBILITY OK`.
- Every task was implemented TDD and passed an independent spec+quality review; three review findings were fixed and re-reviewed (atomic swap rename-aside; CTA stickiness; extraction-label paint yield).
- Manual E2E in a real vault still recommended before release: store-like install (no `webapp/`) → load notice → editor shows instructive error → settings Install with progress → offline editing works → Reinstall works.

## Deferred (noted, non-blocking — triaged by the final review)

- `download()` has no inactivity timeout (stalled socket wedges Installing until plugin reload); prime follow-up candidate.
- Per-chunk progress DOM updates could dedup identical text.
- `download()` error paths (redirect cap, non-200, length mismatch) rely on the feasibility run + inspection rather than unit tests.

Spec: `docs/superpowers/specs/2026-07-11-offline-webapp-install-design.md` · Plan: `docs/superpowers/plans/2026-07-11-offline-webapp-install.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
