### PR TITLE
ci: add PR gate workflow for main (test + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+# PR gate for main: every pull request runs the same test + build pipeline
+# the release workflow uses, so a branch can't merge with a broken build.
+# Also runs on pushes to main as a post-merge baseline. The "test" job name
+# is referenced by main's branch protection required status checks — rename
+# them together.
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# One active run per PR / per branch; a newer push supersedes the old run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      # Downloads the pinned drawio webapp; the build and the viewer-based
+      # test suites need it (see CLAUDE.md).
+      - run: npm run fetch-drawio
+
+      - run: npm test
+
+      - run: npm run build
+
+      - name: Verify build artifacts exist
+        run: test -f main.js && test -f manifest.json && test -f styles.css


### PR DESCRIPTION
## Summary

Adds a CI gate for `main`:

- New workflow `.github/workflows/ci.yml` runs on every pull request targeting `main` (and on pushes to `main` as a post-merge baseline): `npm ci` → `npm run fetch-drawio` → `npm test` → `npm run build` → verify `main.js`/`manifest.json`/`styles.css` exist — the same verification steps the release workflow runs.
- Branch protection on `main` (configured via API alongside this PR) requires the `test` check to pass before merging. Repo admins are exempt from enforcement (`enforce_admins: false`) so the release flow's direct version-bump pushes to `main` keep working; force pushes and branch deletion on `main` are blocked for everyone.

## Notes

- `strict` up-to-date-with-base is left off to keep solo-PR friction low; can be enabled later if stale-base merges become a concern.
- The concurrency group cancels superseded runs on the same PR/branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)