### PR TITLE
feat: dual-format .drawio.svg / .drawio.png files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ The editor needs one of: the offline editor installed (one click in settings, ~5
 | **Code block** | Add a `` ```drawio `` block in any note (start empty, or paste drawio XML) | Click the preview → full-screen modal |
 | **`.drawio` file** | Ribbon button / **Create new diagram** command / folder context menu | Editor embedded directly in the file's tab |
 | **Embed** | `![[your-diagram.drawio]]` in any note | Click the preview → quick-edit modal |
+| **`.drawio.svg` / `.drawio.png` file** | Same entry points, after setting **New diagram format** | Right-click the file → **Edit drawio diagram** |
 
-All three render as SVG previews in both editing and reading views, and every edit autosaves back to its source — the code block's XML or the `.drawio` file. Embeds re-render automatically when the underlying file changes.
+All render as previews in both editing and reading views, and every edit autosaves back to its source — the code block's XML or the diagram file. Embeds re-render automatically when the underlying file changes.
+
+**Dual-format files (`.drawio.svg` / `.drawio.png`):** the file *is* a standard SVG or PNG image with the diagram embedded inside — it displays as a plain image everywhere (GitHub, exports, other tools, Obsidian's own image view and embeds) while staying fully editable here. Set **New diagram format** in the settings to create them by default; edit via the file's context menu (**Edit drawio diagram**) or the **Edit diagram in the current image file** command. Each save re-exports the image part, keeping picture and diagram in sync. Same format as the VS Code drawio extension, so the files are interchangeable.
 
 ![The drawio editor embedded in a file tab](https://raw.githubusercontent.com/doge-liang/obsidian-drawio/main/docs/assets/file-editor.png)
 
@@ -64,6 +67,7 @@ Phones and tablets behave identically: previews everywhere, no editing. Tapping 
 | **Editor source** | **Offline** (bundled webapp, default), **Online** (diagrams.net), or a **Custom URL**. Offline requires the one-time install below — there is no automatic fallback. |
 | **Custom drawio URL** | Used when Editor source is "Custom URL" (e.g. `https://embed.diagrams.net/`). |
 | **New diagram location** | Where the command and ribbon button create diagrams: vault root (default), the current note's folder, or a fixed folder (created if missing). The folder context menu always creates in the clicked folder. |
+| **New diagram format** | `.drawio` (plain XML, default), `.drawio.svg`, or `.drawio.png` — the latter two are standard images with the diagram embedded, viewable anywhere and editable here. |
 | **Open diagram files read-only** | Desktop: show a static preview instead of the embedded editor when opening `.drawio` files — for workflows centred on drawio-desktop. Applies to newly opened tabs. |
 | **Preview click action** | Desktop: what clicking a preview does — open the built-in editor (default), open the file in the system default app, or nothing. Code blocks always use the built-in editor (they have no file). |
 | **Preview alignment** | Center (default) or left-align rendered previews. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,8 +34,11 @@
 | **代码块** | 在任意笔记中添加 `` ```drawio `` 代码块（可留空，或粘贴 drawio XML） | 点击预览 → 全屏模态框 |
 | **`.drawio` 文件** | 侧边栏按钮 / **Create new diagram** 命令 / 文件夹右键菜单 | 编辑器直接嵌入文件的标签页 |
 | **嵌入** | 在任意笔记中写 `![[your-diagram.drawio]]` | 点击预览 → 快速编辑模态框 |
+| **`.drawio.svg` / `.drawio.png` 文件** | 同样的入口，先设置 **New diagram format** | 右键文件 → **Edit drawio diagram** |
 
-三者都在编辑视图和阅读视图中渲染为 SVG 预览，每次编辑都会自动保存回其源头 —— 代码块的 XML 或 `.drawio` 文件。当底层文件变化时，嵌入会自动重新渲染。
+以上载体都在编辑视图和阅读视图中渲染为预览，每次编辑都会自动保存回其源头 —— 代码块的 XML 或图表文件。当底层文件变化时，嵌入会自动重新渲染。
+
+**双格式文件（`.drawio.svg` / `.drawio.png`）**：文件本体*就是*标准的 SVG 或 PNG 图片，图表数据内嵌其中 —— 它在任何地方（GitHub、导出物、其他工具、Obsidian 自身的图片视图与嵌入）都显示为普通图片，同时在这里保持完全可编辑。在设置中选择 **New diagram format** 即可默认创建这类文件；通过文件右键菜单（**Edit drawio diagram**）或 **Edit diagram in the current image file** 命令编辑。每次保存都会重新导出图片部分，使图像与图表保持同步。与 VS Code drawio 扩展格式相同，文件可互换使用。
 
 ![嵌入文件标签页中的 drawio 编辑器](https://raw.githubusercontent.com/doge-liang/obsidian-drawio/main/docs/assets/file-editor.png)
 
@@ -64,6 +67,7 @@
 | **Editor source**（编辑器来源） | **Offline**（打包 webapp，默认）、**Online**（diagrams.net），或 **Custom URL**（自定义 URL）。Offline 需要完成下文的一次性安装 —— 没有自动回退。 |
 | **Custom drawio URL**（自定义 drawio URL） | 当 Editor source 为 “Custom URL” 时使用（例如 `https://embed.diagrams.net/`）。 |
 | **New diagram location**（新图表位置） | 命令和侧边栏按钮创建图表的位置：库根目录（默认）、当前笔记所在文件夹，或固定文件夹（不存在则创建）。文件夹右键菜单始终在被点击的文件夹中创建。 |
+| **New diagram format**（新图表格式） | `.drawio`（纯 XML，默认）、`.drawio.svg` 或 `.drawio.png` —— 后两者是内嵌图表数据的标准图片，随处可看，在此可编辑。 |
 | **Open diagram files read-only**（以只读方式打开图表文件） | 桌面端：打开 `.drawio` 文件时显示静态预览而非内嵌编辑器 —— 适用于以 drawio-desktop 为中心的工作流。对新打开的标签页生效。 |
 | **Preview click action**（预览点击行为） | 桌面端：点击预览的行为 —— 打开内置编辑器（默认）、用系统默认应用打开文件，或什么都不做。代码块始终使用内置编辑器（它们没有对应文件）。 |
 | **Preview alignment**（预览对齐） | 渲染的预览居中（默认）或左对齐。 |

--- a/src/desktop/registerDesktopFeatures.ts
+++ b/src/desktop/registerDesktopFeatures.ts
@@ -1,7 +1,9 @@
-import { FileSystemAdapter, Notice, TFolder } from 'obsidian';
+import { FileSystemAdapter, Notice, TFile, TFolder } from 'obsidian';
 import { join } from 'node:path';
 import { ServerManager } from '../server/ServerManager';
 import { createNewDiagram } from '../file/createDiagram';
+import { DualFormatFileSource } from '../file/DualFormatFileSource';
+import { dualFormatOf } from '../model/dualFormat';
 import type DrawioPlugin from '../main';
 
 /**
@@ -36,15 +38,39 @@ export async function registerDesktopFeatures(plugin: DrawioPlugin): Promise<voi
     void createNewDiagram(plugin);
   });
 
-  // "New drawio diagram" on folder context menus, creating in that folder.
+  // "New drawio diagram" on folder context menus, creating in that folder;
+  // "Edit drawio diagram" on dual-format image files (which open in
+  // Obsidian's own image view, so they need an explicit editor entry).
   plugin.registerEvent(plugin.app.workspace.on('file-menu', (menu, file) => {
     if (file instanceof TFolder) {
       menu.addItem((item) => item
         .setTitle('New drawio diagram')
         .setIcon('workflow')
         .onClick(() => { void createNewDiagram(plugin, file); }));
+    } else if (file instanceof TFile) {
+      const format = dualFormatOf(file.path);
+      if (format) {
+        menu.addItem((item) => item
+          .setTitle('Edit drawio diagram')
+          .setIcon('workflow')
+          .onClick(() => {
+            plugin.openEditor(new DualFormatFileSource(plugin.app, file, format));
+          }));
+      }
     }
   }));
+
+  plugin.addCommand({
+    id: 'edit-dual-format-diagram',
+    name: 'Edit diagram in the current image file',
+    checkCallback: (checking) => {
+      const file = plugin.app.workspace.getActiveFile();
+      const format = file ? dualFormatOf(file.path) : null;
+      if (!file || !format) return false;
+      if (!checking) plugin.openEditor(new DualFormatFileSource(plugin.app, file, format));
+      return true;
+    },
+  });
 
   // Lifecycle detection: offline mode selected but the webapp isn't installed.
   // One notice per plugin load — the settings tab carries the actual installer.

--- a/src/editor/DrawioEditor.ts
+++ b/src/editor/DrawioEditor.ts
@@ -1,6 +1,8 @@
 import { Notice } from 'obsidian';
-import { DrawioSource } from '../model/DrawioSource';
-import { buildLoadMessage, buildConfigureMessage, parseDrawioEvent } from './embedMessages';
+import { DrawioSource, isExportingSource } from '../model/DrawioSource';
+import {
+  buildLoadMessage, buildConfigureMessage, buildExportMessage, parseDrawioEvent,
+} from './embedMessages';
 import { buildEmbedQuery } from '../constants';
 
 export interface DrawioEditorDeps {
@@ -35,6 +37,12 @@ export class DrawioEditor {
    * postMessage replies, which are dispatched on ITS parent window, not the
    * main app window. */
   private win: Window = window;
+  /** Export round-trip state for dual-format sources: save/autosave answers
+   * with an export request, and the export event does the actual persist.
+   * Overlapping requests are coalesced into one trailing re-request. */
+  private exportPending = false;
+  private exportQueued = false;
+  private exitAfterExport = false;
 
   constructor(
     private container: HTMLElement,
@@ -111,6 +119,13 @@ export class DrawioEditor {
       }
       case 'save':
       case 'autosave': {
+        if (isExportingSource(this.source)) {
+          // The event's xml alone can't be persisted (the file body is an
+          // image); ask the editor for a fresh export and save on its reply.
+          if (ev.event === 'save' && (ev as { exit?: boolean }).exit) this.exitAfterExport = true;
+          this.requestExport();
+          break;
+        }
         try {
           await this.source.write((ev as { xml: string }).xml);
         } catch (err) {
@@ -120,10 +135,36 @@ export class DrawioEditor {
         if (ev.event === 'save' && (ev as { exit?: boolean }).exit) this.options.onExit?.();
         break;
       }
+      case 'export': {
+        if (!isExportingSource(this.source)) break;
+        this.exportPending = false;
+        const again = this.exportQueued;
+        this.exportQueued = false;
+        try {
+          await this.source.writeExport((ev as { data: string }).data);
+        } catch (err) {
+          new Notice('Drawio: failed to save diagram');
+          console.error(err);
+        }
+        if (again) {
+          this.requestExport();
+        } else if (this.exitAfterExport) {
+          this.exitAfterExport = false;
+          this.options.onExit?.();
+        }
+        break;
+      }
       case 'exit':
         this.options.onExit?.();
         break;
     }
+  }
+
+  private requestExport(): void {
+    if (this.exportPending) { this.exportQueued = true; return; }
+    if (!isExportingSource(this.source)) return;
+    this.exportPending = true;
+    this.post(buildExportMessage(this.source.exportFormat()));
   }
 
   private post(message: string): void {

--- a/src/editor/DrawioEditor.ts
+++ b/src/editor/DrawioEditor.ts
@@ -18,7 +18,12 @@ export interface DrawioEditorDeps {
 export interface DrawioEditorOptions {
   /** Called when drawio emits an `exit` event (e.g. user clicks the editor's close). */
   onExit?: () => void;
+  /** How long to wait for drawio's export reply before falling back to an
+   * XML-only write (tests shrink this; defaults to 15 s). */
+  exportTimeoutMs?: number;
 }
+
+const DEFAULT_EXPORT_TIMEOUT_MS = 15_000;
 
 /**
  * Reusable drawio editor surface: an <iframe> loading the drawio webapp in embed
@@ -39,10 +44,15 @@ export class DrawioEditor {
   private win: Window = window;
   /** Export round-trip state for dual-format sources: save/autosave answers
    * with an export request, and the export event does the actual persist.
-   * Overlapping requests are coalesced into one trailing re-request. */
+   * Overlapping requests are coalesced into one trailing re-request. The XML
+   * from the latest save/autosave event is kept so that a torn-down or
+   * unanswered export can still fall back to an XML-only write — the diagram
+   * data must never be lost, even if the image part goes stale. */
   private exportPending = false;
   private exportQueued = false;
   private exitAfterExport = false;
+  private lastXml: string | null = null;
+  private exportTimer: number | null = null;
 
   constructor(
     private container: HTMLElement,
@@ -120,8 +130,10 @@ export class DrawioEditor {
       case 'save':
       case 'autosave': {
         if (isExportingSource(this.source)) {
-          // The event's xml alone can't be persisted (the file body is an
-          // image); ask the editor for a fresh export and save on its reply.
+          // The event's xml alone can't be persisted as-is (the file body is
+          // an image); ask the editor for a fresh export and save on its
+          // reply. Keep the xml for the fallback paths.
+          this.lastXml = (ev as { xml: string }).xml;
           if (ev.event === 'save' && (ev as { exit?: boolean }).exit) this.exitAfterExport = true;
           this.requestExport();
           break;
@@ -137,6 +149,7 @@ export class DrawioEditor {
       }
       case 'export': {
         if (!isExportingSource(this.source)) break;
+        this.clearExportTimer();
         this.exportPending = false;
         const again = this.exportQueued;
         this.exportQueued = false;
@@ -164,7 +177,35 @@ export class DrawioEditor {
     if (this.exportPending) { this.exportQueued = true; return; }
     if (!isExportingSource(this.source)) return;
     this.exportPending = true;
+    this.clearExportTimer();
+    this.exportTimer = window.setTimeout(() => { void this.onExportTimeout(); },
+      this.options.exportTimeoutMs ?? DEFAULT_EXPORT_TIMEOUT_MS);
     this.post(buildExportMessage(this.source.exportFormat()));
+  }
+
+  private clearExportTimer(): void {
+    if (this.exportTimer !== null) { window.clearTimeout(this.exportTimer); this.exportTimer = null; }
+  }
+
+  /** drawio never answered the export request: fall back to writing the XML
+   * alone (the image part stays stale until the next successful save), so the
+   * user's data survives and a pending save-and-exit doesn't hang forever. */
+  private async onExportTimeout(): Promise<void> {
+    if (this.destroyed || !this.exportPending) return;
+    this.exportTimer = null;
+    this.exportPending = false;
+    this.exportQueued = false;
+    const exit = this.exitAfterExport;
+    this.exitAfterExport = false;
+    try {
+      if (this.lastXml !== null) await this.source.write(this.lastXml);
+      new Notice('Drawio: the editor did not return an export — the diagram data was saved, ' +
+        'but the image may be outdated until the next save.');
+    } catch (err) {
+      new Notice('Drawio: failed to save diagram');
+      console.error(err);
+    }
+    if (exit) this.options.onExit?.();
   }
 
   private post(message: string): void {
@@ -200,6 +241,19 @@ export class DrawioEditor {
 
   destroy(): void {
     this.destroyed = true;
+    this.clearExportTimer();
+    // Torn down while an export round-trip is in flight (e.g. the modal
+    // closed right after an autosave): the reply will never arrive, so
+    // persist the last known XML now. The vault write survives the teardown;
+    // only the image part stays stale until the next editor save.
+    if ((this.exportPending || this.exportQueued) && this.lastXml !== null) {
+      this.source.write(this.lastXml).catch((err) => {
+        new Notice('Drawio: failed to save diagram');
+        console.error(err);
+      });
+      this.exportPending = false;
+      this.exportQueued = false;
+    }
     if (this.onMessage) this.win.removeEventListener('message', this.onMessage);
     this.onMessage = null;
     this.iframe = null;

--- a/src/editor/embedMessages.ts
+++ b/src/editor/embedMessages.ts
@@ -11,7 +11,7 @@ export function buildLoadMessage(xml: string, opts: { dark: boolean }): string {
   return JSON.stringify({ action: 'load', xml, autosave: 1, modified: 0, dark: opts.dark });
 }
 
-export function buildExportMessage(format: 'svg' | 'png' | 'xmlpng'): string {
+export function buildExportMessage(format: 'svg' | 'png' | 'xmlsvg' | 'xmlpng'): string {
   return JSON.stringify({ action: 'export', format });
 }
 

--- a/src/file/DualFormatFileSource.ts
+++ b/src/file/DualFormatFileSource.ts
@@ -1,7 +1,8 @@
 import { App, TFile } from 'obsidian';
 import { ExportingSource } from '../model/DrawioSource';
 import {
-  DualFormat, decodeDataUri, extractXmlFromPng, extractXmlFromSvg,
+  DualFormat, buildInitialPng, buildInitialSvg, decodeDataUri,
+  extractXmlFromPng, extractXmlFromSvg, replaceXmlInPng, replaceXmlInSvg,
 } from '../model/dualFormat';
 import { EMPTY_DIAGRAM } from '../constants';
 
@@ -47,9 +48,23 @@ export class DualFormatFileSource implements ExportingSource {
     await this.app.vault.modifyBinary(this.file, copy);
   }
 
-  async write(): Promise<void> {
-    // Never called by the editor for exporting sources; a plain XML body
-    // would destroy the image half of the file.
-    throw new Error('dual-format files are saved via writeExport');
+  /** Fallback persistence when no export payload is available (editor torn
+   * down mid-export, or drawio never replied): swap only the embedded XML so
+   * the diagram data — the source of truth — is never lost. The image part
+   * goes stale until the next save from the editor re-exports it. */
+  async write(xml: string): Promise<void> {
+    if (this.format === 'svg') {
+      const text = await this.app.vault.read(this.file);
+      const body = text.trim() ? replaceXmlInSvg(text, xml) : buildInitialSvg(xml);
+      if (body === null) throw new Error(`"${this.file.name}" is not a valid SVG`);
+      await this.app.vault.modify(this.file, body);
+      return;
+    }
+    const bytes = await this.app.vault.readBinary(this.file);
+    const next = bytes.byteLength === 0 ? buildInitialPng(xml) : replaceXmlInPng(bytes, xml);
+    if (next === null) throw new Error(`"${this.file.name}" is not a valid PNG`);
+    const copy = new ArrayBuffer(next.byteLength);
+    new Uint8Array(copy).set(next);
+    await this.app.vault.modifyBinary(this.file, copy);
   }
 }

--- a/src/file/DualFormatFileSource.ts
+++ b/src/file/DualFormatFileSource.ts
@@ -1,0 +1,55 @@
+import { App, TFile } from 'obsidian';
+import { ExportingSource } from '../model/DrawioSource';
+import {
+  DualFormat, decodeDataUri, extractXmlFromPng, extractXmlFromSvg,
+} from '../model/dualFormat';
+import { EMPTY_DIAGRAM } from '../constants';
+
+/** Edit target for dual-format files (`*.drawio.svg` / `*.drawio.png`):
+ * reading extracts the embedded XML from the image body; saving goes through
+ * the editor's export round-trip (see {@link ExportingSource}). */
+export class DualFormatFileSource implements ExportingSource {
+  constructor(private app: App, private file: TFile, private format: DualFormat) {}
+
+  title(): string {
+    // basename of "a.drawio.svg" is "a.drawio" — drop the inner suffix too.
+    const n = this.file.basename;
+    return n.toLowerCase().endsWith('.drawio') ? n.slice(0, -'.drawio'.length) : n;
+  }
+
+  async read(): Promise<string> {
+    if (this.format === 'svg') {
+      const text = await this.app.vault.read(this.file);
+      if (!text.trim()) return EMPTY_DIAGRAM;
+      const xml = extractXmlFromSvg(text);
+      if (xml === null) throw new Error(`"${this.file.name}" has no embedded drawio diagram`);
+      return xml;
+    }
+    const bytes = await this.app.vault.readBinary(this.file);
+    if (bytes.byteLength === 0) return EMPTY_DIAGRAM;
+    const xml = extractXmlFromPng(bytes);
+    if (xml === null) throw new Error(`"${this.file.name}" has no embedded drawio diagram`);
+    return xml;
+  }
+
+  exportFormat(): 'xmlsvg' | 'xmlpng' {
+    return this.format === 'svg' ? 'xmlsvg' : 'xmlpng';
+  }
+
+  async writeExport(dataUri: string): Promise<void> {
+    const bytes = decodeDataUri(dataUri);
+    if (this.format === 'svg') {
+      await this.app.vault.modify(this.file, new TextDecoder().decode(bytes));
+      return;
+    }
+    const copy = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(copy).set(bytes);
+    await this.app.vault.modifyBinary(this.file, copy);
+  }
+
+  async write(): Promise<void> {
+    // Never called by the editor for exporting sources; a plain XML body
+    // would destroy the image half of the file.
+    throw new Error('dual-format files are saved via writeExport');
+  }
+}

--- a/src/file/createDiagram.ts
+++ b/src/file/createDiagram.ts
@@ -1,7 +1,9 @@
-import { Notice, TFolder } from 'obsidian';
+import { Notice, TFile, TFolder } from 'obsidian';
 import type DrawioPlugin from '../main';
 import type { DrawioSettings } from '../settings';
 import { EMPTY_DIAGRAM } from '../constants';
+import { buildInitialPng, buildInitialSvg } from '../model/dualFormat';
+import { DualFormatFileSource } from './DualFormatFileSource';
 
 /** Normalize a vault folder path: forward slashes, no empty/leading/trailing segments. */
 function normalizeFolderPath(path: string): string {
@@ -54,10 +56,28 @@ export async function createNewDiagram(plugin: DrawioPlugin, folderOverride?: TF
       folder = resolveNewDiagramFolder(plugin.settings, parent);
       if (!(await ensureFolderExists(plugin, folder))) return;
     }
-    const name = `Untitled Diagram ${Date.now()}.drawio`;
-    const file = await plugin.app.vault.create(folder ? `${folder}/${name}` : name, EMPTY_DIAGRAM);
-    const leaf = plugin.app.workspace.getLeaf(true);
-    await leaf.openFile(file);
+    const format = plugin.settings.newDiagramFormat;
+    const ext = format === 'drawio' ? '.drawio' : `.drawio.${format}`;
+    const path = `${folder ? `${folder}/` : ''}Untitled Diagram ${Date.now()}${ext}`;
+    let file: TFile;
+    if (format === 'png') {
+      const bytes = buildInitialPng(EMPTY_DIAGRAM);
+      const buf = new ArrayBuffer(bytes.byteLength);
+      new Uint8Array(buf).set(bytes);
+      file = await plugin.app.vault.createBinary(path, buf);
+    } else {
+      const body = format === 'svg' ? buildInitialSvg(EMPTY_DIAGRAM) : EMPTY_DIAGRAM;
+      file = await plugin.app.vault.create(path, body);
+    }
+    if (format === 'drawio') {
+      // Our registered file view carries the editor inline.
+      const leaf = plugin.app.workspace.getLeaf(true);
+      await leaf.openFile(file);
+    } else {
+      // Dual-format files open in Obsidian's own image view, so go straight
+      // to the modal editor instead; the image body fills in on first save.
+      plugin.openEditor(new DualFormatFileSource(plugin.app, file, format));
+    }
   } catch (err) {
     new Notice(`Drawio: could not create diagram — ${String(err)}`);
   }

--- a/src/model/DrawioSource.ts
+++ b/src/model/DrawioSource.ts
@@ -7,3 +7,19 @@ export interface DrawioSource {
   /** Persist new XML. */
   write(xml: string): Promise<void>;
 }
+
+/** A source whose on-disk body is an exported image with the XML embedded
+ * (dual-format files): saving needs the editor's export payload — a plain
+ * XML write would corrupt the image — so the editor answers save/autosave
+ * with an export request and persists through {@link writeExport}. */
+export interface ExportingSource extends DrawioSource {
+  /** The embed-protocol export format producing the on-disk body. */
+  exportFormat(): 'xmlsvg' | 'xmlpng';
+  /** Persist an export payload (the `data:` URI from the export event). */
+  writeExport(dataUri: string): Promise<void>;
+}
+
+export function isExportingSource(source: DrawioSource): source is ExportingSource {
+  const s = source as Partial<ExportingSource>;
+  return typeof s.exportFormat === 'function' && typeof s.writeExport === 'function';
+}

--- a/src/model/dualFormat.ts
+++ b/src/model/dualFormat.ts
@@ -45,6 +45,17 @@ export function buildInitialSvg(xml: string): string {
     `content="${escapeXmlAttr(xml)}"></svg>`;
 }
 
+/** Swap the embedded XML in an existing SVG body, leaving the rendered image
+ * untouched (it goes stale until the next editor save re-exports it), or null
+ * when the text isn't an SVG. */
+export function replaceXmlInSvg(svg: string, xml: string): string | null {
+  const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  const root = doc.documentElement;
+  if (!root || root.tagName.toLowerCase() !== 'svg') return null;
+  root.setAttribute('content', xml);
+  return new XMLSerializer().serializeToString(doc);
+}
+
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 const PNG_TEXT_KEYWORD = 'mxfile';
 
@@ -117,9 +128,8 @@ export function base64ToBytes(b64: string): Uint8Array {
   return out;
 }
 
-/** Minimal valid PNG carrying the given diagram XML in a tEXt chunk. */
-export function buildInitialPng(xml: string): Uint8Array {
-  const base = base64ToBytes(EMPTY_PNG_BASE64);
+/** A tEXt chunk (length + type + keyword\0value + CRC) holding the XML. */
+function makeMxfileChunk(xml: string): Uint8Array {
   // The chunk value must be Latin-1; encodeURIComponent leaves only ASCII.
   const value = encodeURIComponent(xml);
   const payloadLen = PNG_TEXT_KEYWORD.length + 1 + value.length;
@@ -130,13 +140,55 @@ export function buildInitialPng(xml: string): Uint8Array {
   for (let i = 0; i < 4; i++) chunk[4 + i] = 'tEXt'.charCodeAt(i);
   for (let i = 0; i < typeAndData.length; i++) chunk[8 + i] = typeAndData.charCodeAt(i);
   view.setUint32(8 + payloadLen, crc32(chunk.subarray(4, 8 + payloadLen)));
+  return chunk;
+}
 
+/** Minimal valid PNG carrying the given diagram XML in a tEXt chunk. */
+export function buildInitialPng(xml: string): Uint8Array {
+  const base = base64ToBytes(EMPTY_PNG_BASE64);
+  const chunk = makeMxfileChunk(xml);
   // Insert before IEND (the last 12 bytes of a minimal PNG).
   const iendStart = base.length - 12;
   const out = new Uint8Array(base.length + chunk.length);
   out.set(base.subarray(0, iendStart), 0);
   out.set(chunk, iendStart);
   out.set(base.subarray(iendStart), iendStart + chunk.length);
+  return out;
+}
+
+/** Swap the embedded XML in an existing PNG (dropping any previous mxfile
+ * chunk), leaving the image data untouched — it goes stale until the next
+ * editor save re-exports it. Null when the bytes aren't a valid PNG. */
+export function replaceXmlInPng(data: ArrayBuffer | Uint8Array, xml: string): Uint8Array | null {
+  const u8 = data instanceof Uint8Array ? data : new Uint8Array(data);
+  if (u8.length < PNG_SIGNATURE.length) return null;
+  for (let i = 0; i < PNG_SIGNATURE.length; i++) if (u8[i] !== PNG_SIGNATURE[i]) return null;
+  const view = new DataView(u8.buffer, u8.byteOffset, u8.byteLength);
+  const kept: Array<[number, number]> = []; // chunk [start, end) ranges to copy
+  let iendStart = -1;
+  let off = PNG_SIGNATURE.length;
+  while (off + 8 <= u8.length) {
+    const len = view.getUint32(off);
+    const type = latin1(u8, off + 4, off + 8);
+    const end = off + 8 + len + 4;
+    if (end > u8.length) return null;
+    const isMxfileText = type === 'tEXt' &&
+      latin1(u8, off + 8, off + 8 + PNG_TEXT_KEYWORD.length + 1) === PNG_TEXT_KEYWORD + '\0';
+    if (!isMxfileText) kept.push([off, end]);
+    if (type === 'IEND') { iendStart = off; break; }
+    off = end;
+  }
+  if (iendStart < 0) return null;
+  const chunk = makeMxfileChunk(xml);
+  const keptLen = kept.reduce((sum, [s, e]) => sum + (e - s), 0);
+  const out = new Uint8Array(PNG_SIGNATURE.length + keptLen + chunk.length);
+  out.set(u8.subarray(0, PNG_SIGNATURE.length), 0);
+  let cursor = PNG_SIGNATURE.length;
+  for (const [s, e] of kept) {
+    if (s === iendStart) { out.set(chunk, cursor); cursor += chunk.length; }
+    out.set(u8.subarray(s, e), cursor);
+    cursor += e - s;
+  }
   return out;
 }
 

--- a/src/model/dualFormat.ts
+++ b/src/model/dualFormat.ts
@@ -1,0 +1,151 @@
+/**
+ * Dual-format drawio files (`*.drawio.svg` / `*.drawio.png`): the file body is
+ * a standard SVG or PNG image with the diagram XML embedded inside — SVG keeps
+ * it in the root element's `content` attribute, PNG in a `tEXt` chunk with
+ * keyword `mxfile` (URI-encoded). This is the format drawio itself exports for
+ * `xmlsvg`/`xmlpng` and the one the VS Code drawio extension edits in place,
+ * so the files render as plain images everywhere (GitHub, other tools,
+ * Obsidian's own image view) while staying fully editable.
+ *
+ * Everything in this module is pure data transformation with no Node or
+ * Electron APIs, so it is safe to load on mobile.
+ */
+
+export type DualFormat = 'svg' | 'png';
+
+/** The dual format a path denotes, or null for anything else (incl. plain `.drawio`). */
+export function dualFormatOf(path: string): DualFormat | null {
+  const p = path.toLowerCase();
+  if (p.endsWith('.drawio.svg')) return 'svg';
+  if (p.endsWith('.drawio.png')) return 'png';
+  return null;
+}
+
+/** Extract the embedded diagram XML from an exported SVG, or null when absent. */
+export function extractXmlFromSvg(svg: string): string | null {
+  const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  const root = doc.documentElement;
+  if (!root || root.tagName.toLowerCase() !== 'svg') return null;
+  const content = root.getAttribute('content');
+  return content && content.trim() ? content : null;
+}
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Minimal valid SVG carrying the given diagram XML — the initial body of a
+ * newly created `.drawio.svg`, replaced by a real export on first save. */
+export function buildInitialSvg(xml: string): string {
+  return '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1" height="1" ' +
+    `content="${escapeXmlAttr(xml)}"></svg>`;
+}
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const PNG_TEXT_KEYWORD = 'mxfile';
+
+/** A 1×1 transparent PNG (no text chunks) — the image part of a newly created
+ * `.drawio.png`, replaced by a real export on first save. */
+const EMPTY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+function latin1(bytes: Uint8Array, start: number, end: number): string {
+  let out = '';
+  for (let i = start; i < end; i++) out += String.fromCharCode(bytes[i] ?? 0);
+  return out;
+}
+
+/** Extract the embedded diagram XML from an exported PNG (tEXt chunk with
+ * keyword `mxfile`, URI-encoded value), or null when absent or not a PNG. */
+export function extractXmlFromPng(data: ArrayBuffer | Uint8Array): string | null {
+  const u8 = data instanceof Uint8Array ? data : new Uint8Array(data);
+  if (u8.length < PNG_SIGNATURE.length) return null;
+  for (let i = 0; i < PNG_SIGNATURE.length; i++) if (u8[i] !== PNG_SIGNATURE[i]) return null;
+  const view = new DataView(u8.buffer, u8.byteOffset, u8.byteLength);
+  let off = PNG_SIGNATURE.length;
+  while (off + 8 <= u8.length) {
+    const len = view.getUint32(off);
+    const type = latin1(u8, off + 4, off + 8);
+    const dataStart = off + 8;
+    if (dataStart + len > u8.length) return null;
+    if (type === 'tEXt') {
+      let nul = -1;
+      for (let i = dataStart; i < dataStart + len; i++) {
+        if (u8[i] === 0) { nul = i; break; }
+      }
+      if (nul > dataStart && latin1(u8, dataStart, nul) === PNG_TEXT_KEYWORD) {
+        try {
+          return decodeURIComponent(latin1(u8, nul + 1, dataStart + len));
+        } catch {
+          return null;
+        }
+      }
+    }
+    if (type === 'IEND') break;
+    off = dataStart + len + 4; // skip data + CRC
+  }
+  return null;
+}
+
+let crcTable: Uint32Array | null = null;
+
+/** CRC-32 as specified by the PNG chunk format. */
+function crc32(bytes: Uint8Array): number {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+      let c = n;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      crcTable[n] = c >>> 0;
+    }
+  }
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) {
+    crc = (crcTable[(crc ^ (bytes[i] ?? 0)) & 0xff] ?? 0) ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** Minimal valid PNG carrying the given diagram XML in a tEXt chunk. */
+export function buildInitialPng(xml: string): Uint8Array {
+  const base = base64ToBytes(EMPTY_PNG_BASE64);
+  // The chunk value must be Latin-1; encodeURIComponent leaves only ASCII.
+  const value = encodeURIComponent(xml);
+  const payloadLen = PNG_TEXT_KEYWORD.length + 1 + value.length;
+  const chunk = new Uint8Array(8 + payloadLen + 4);
+  const view = new DataView(chunk.buffer);
+  view.setUint32(0, payloadLen);
+  const typeAndData = PNG_TEXT_KEYWORD + '\0' + value;
+  for (let i = 0; i < 4; i++) chunk[4 + i] = 'tEXt'.charCodeAt(i);
+  for (let i = 0; i < typeAndData.length; i++) chunk[8 + i] = typeAndData.charCodeAt(i);
+  view.setUint32(8 + payloadLen, crc32(chunk.subarray(4, 8 + payloadLen)));
+
+  // Insert before IEND (the last 12 bytes of a minimal PNG).
+  const iendStart = base.length - 12;
+  const out = new Uint8Array(base.length + chunk.length);
+  out.set(base.subarray(0, iendStart), 0);
+  out.set(chunk, iendStart);
+  out.set(base.subarray(iendStart), iendStart + chunk.length);
+  return out;
+}
+
+/** Decode a `data:` URI (as the drawio export event delivers) into bytes. */
+export function decodeDataUri(uri: string): Uint8Array {
+  const comma = uri.indexOf(',');
+  if (!uri.startsWith('data:') || comma < 0) throw new Error('not a data: URI');
+  const meta = uri.slice(5, comma);
+  const payload = uri.slice(comma + 1);
+  if (meta.endsWith(';base64')) return base64ToBytes(payload);
+  return new TextEncoder().encode(decodeURIComponent(payload));
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,10 @@
 export type DrawioMode = 'online' | 'offline' | 'custom';
 export type StoreFormat = 'xml' | 'compressed';
 export type NewDiagramLocation = 'root' | 'current' | 'folder';
+/** File format for newly created diagrams: plain XML, or a dual-format image
+ * (standard SVG/PNG with the diagram XML embedded — renders as an image
+ * everywhere, editable here). */
+export type NewDiagramFormat = 'drawio' | 'svg' | 'png';
 export type PreviewAlignment = 'center' | 'left';
 export type PreviewClickAction = 'editor' | 'defaultApp' | 'none';
 
@@ -16,6 +20,7 @@ export interface DrawioSettings {
   newDiagramLocation: NewDiagramLocation;
   /** Target folder for new diagrams when newDiagramLocation is 'folder'. */
   newDiagramFolder: string;
+  newDiagramFormat: NewDiagramFormat;
   previewAlignment: PreviewAlignment;
   /** Desktop: open .drawio files as a static preview instead of the editor. */
   readonlyFileView: boolean;
@@ -34,6 +39,7 @@ export const DEFAULT_SETTINGS: DrawioSettings = {
   storeFormat: 'xml',
   newDiagramLocation: 'root',
   newDiagramFolder: '',
+  newDiagramFormat: 'drawio',
   previewAlignment: 'center',
   readonlyFileView: false,
   previewClickAction: 'editor',

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -2,7 +2,9 @@ import { App, ButtonComponent, Platform, PluginSettingTab, Setting } from 'obsid
 import type DrawioPlugin from './main';
 import { DRAWIO_VERSION } from './constants';
 import { formatInstallProgress, type WebappInstallState } from './model/installStatus';
-import type { DrawioMode, NewDiagramLocation, PreviewAlignment, PreviewClickAction } from './settings';
+import type {
+  DrawioMode, NewDiagramFormat, NewDiagramLocation, PreviewAlignment, PreviewClickAction,
+} from './settings';
 
 /**
  * Settings tab, rendered with the classic imperative `display()` API.
@@ -75,6 +77,20 @@ export class DrawioSettingTab extends PluginSettingTab {
           .addOption('folder', 'Folder specified below')
           .setValue(s.newDiagramLocation)
           .onChange((v) => { s.newDiagramLocation = v as NewDiagramLocation; save(); this.display(); }));
+
+      new Setting(containerEl)
+        .setName('New diagram format')
+        .setDesc(
+          '.drawio stores plain XML. .drawio.svg and .drawio.png are standard images with the ' +
+          'diagram embedded — they display as images everywhere and stay editable here ' +
+          '(right-click the file and choose "Edit drawio diagram").',
+        )
+        .addDropdown((d) => d
+          .addOption('drawio', '.drawio')
+          .addOption('svg', '.drawio.svg')
+          .addOption('png', '.drawio.png')
+          .setValue(s.newDiagramFormat)
+          .onChange((v) => { s.newDiagramFormat = v as NewDiagramFormat; save(); }));
 
       // Target folder, only relevant when the location is a fixed folder.
       if (s.newDiagramLocation === 'folder') {

--- a/tests/drawioEditorExport.test.ts
+++ b/tests/drawioEditorExport.test.ts
@@ -16,14 +16,15 @@ function makeDeps(): DrawioEditorDeps {
 
 function makeExportingSource() {
   const writes: string[] = [];
+  const xmlWrites: string[] = [];
   const source: ExportingSource = {
     title: () => 'dual',
     read: async () => '<mxfile/>',
-    write: async () => { throw new Error('unexpected XML write'); },
+    write: async (xml: string) => { xmlWrites.push(xml); },
     exportFormat: () => 'xmlsvg',
     writeExport: async (uri: string) => { writes.push(uri); },
   };
-  return { source, writes };
+  return { source, writes, xmlWrites };
 }
 
 async function flush() {
@@ -45,8 +46,8 @@ describe('DrawioEditor export round-trip (dual-format sources)', () => {
     }));
   }
 
-  async function mount(source: ExportingSource) {
-    editor = new DrawioEditor(container, source, makeDeps(), { onExit });
+  async function mount(source: ExportingSource, exportTimeoutMs?: number) {
+    editor = new DrawioEditor(container, source, makeDeps(), { onExit, exportTimeoutMs });
     await editor.mount();
     const cw = container.querySelector('iframe')!.contentWindow!;
     vi.spyOn(cw, 'postMessage').mockImplementation((msg: unknown) => {
@@ -114,5 +115,28 @@ describe('DrawioEditor export round-trip (dual-format sources)', () => {
     dispatch({ event: 'export', format: 'xmlsvg', data: 'data:image/svg+xml;base64,Yg==' });
     await flush();
     expect(writes).toHaveLength(2);
+  });
+
+  it('destroy() during a pending export falls back to writing the last XML', async () => {
+    const { source, writes, xmlWrites } = makeExportingSource();
+    await mount(source);
+    dispatch({ event: 'autosave', xml: '<mxfile>edited</mxfile>' });
+    await flush();
+    editor!.destroy();
+    editor = null;
+    await flush();
+    expect(xmlWrites).toEqual(['<mxfile>edited</mxfile>']); // data survives the teardown
+    expect(writes).toEqual([]);
+  });
+
+  it('an unanswered export times out into an XML fallback and completes a pending exit', async () => {
+    const { source, xmlWrites } = makeExportingSource();
+    await mount(source, 30);
+    dispatch({ event: 'save', xml: '<mxfile>final</mxfile>', exit: true });
+    await flush();
+    expect(onExit).not.toHaveBeenCalled();
+    await new Promise((r) => window.setTimeout(r, 80)); // past the 30 ms timeout
+    expect(xmlWrites).toEqual(['<mxfile>final</mxfile>']);
+    expect(onExit).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/drawioEditorExport.test.ts
+++ b/tests/drawioEditorExport.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DrawioEditor, DrawioEditorDeps } from '../src/editor/DrawioEditor';
+import type { ExportingSource } from '../src/model/DrawioSource';
+
+const ORIGIN = 'http://127.0.0.1:1234';
+
+function makeDeps(): DrawioEditorDeps {
+  return {
+    resolveBaseUrl: async () => `${ORIGIN}/index.html`,
+    isDark: () => false,
+    showLibraries: () => true,
+    acquireServer: vi.fn(),
+    releaseServer: vi.fn(),
+  };
+}
+
+function makeExportingSource() {
+  const writes: string[] = [];
+  const source: ExportingSource = {
+    title: () => 'dual',
+    read: async () => '<mxfile/>',
+    write: async () => { throw new Error('unexpected XML write'); },
+    exportFormat: () => 'xmlsvg',
+    writeExport: async (uri: string) => { writes.push(uri); },
+  };
+  return { source, writes };
+}
+
+async function flush() {
+  await new Promise((r) => window.setTimeout(r, 0));
+}
+
+describe('DrawioEditor export round-trip (dual-format sources)', () => {
+  let container: HTMLElement;
+  let editor: DrawioEditor | null = null;
+  let posts: string[];
+  let onExit: ReturnType<typeof vi.fn>;
+
+  function dispatch(data: unknown) {
+    const iframe = container.querySelector('iframe')!;
+    window.dispatchEvent(new MessageEvent('message', {
+      data: JSON.stringify(data),
+      origin: ORIGIN,
+      source: iframe.contentWindow,
+    }));
+  }
+
+  async function mount(source: ExportingSource) {
+    editor = new DrawioEditor(container, source, makeDeps(), { onExit });
+    await editor.mount();
+    const cw = container.querySelector('iframe')!.contentWindow!;
+    vi.spyOn(cw, 'postMessage').mockImplementation((msg: unknown) => {
+      posts.push(msg as string);
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    posts = [];
+    onExit = vi.fn();
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = null;
+    container.remove();
+  });
+
+  it('answers save with an export request instead of writing the XML', async () => {
+    const { source, writes } = makeExportingSource();
+    await mount(source);
+    dispatch({ event: 'save', xml: '<mxfile/>' });
+    await flush();
+    expect(posts).toContainEqual(JSON.stringify({ action: 'export', format: 'xmlsvg' }));
+    expect(writes).toEqual([]); // nothing persisted until the export reply
+  });
+
+  it('persists the export payload when the export event arrives', async () => {
+    const { source, writes } = makeExportingSource();
+    await mount(source);
+    dispatch({ event: 'save', xml: '<mxfile/>' });
+    await flush();
+    dispatch({ event: 'export', format: 'xmlsvg', data: 'data:image/svg+xml;base64,YQ==' });
+    await flush();
+    expect(writes).toEqual(['data:image/svg+xml;base64,YQ==']);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('defers exit-on-save until the export has been persisted', async () => {
+    const { source, writes } = makeExportingSource();
+    await mount(source);
+    dispatch({ event: 'save', xml: '<mxfile/>', exit: true });
+    await flush();
+    expect(onExit).not.toHaveBeenCalled(); // still waiting for the export
+    dispatch({ event: 'export', format: 'xmlsvg', data: 'data:image/svg+xml;base64,YQ==' });
+    await flush();
+    expect(writes).toHaveLength(1);
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces overlapping autosaves into one trailing re-export', async () => {
+    const { source, writes } = makeExportingSource();
+    await mount(source);
+    dispatch({ event: 'autosave', xml: '<a/>' });
+    dispatch({ event: 'autosave', xml: '<b/>' });
+    await flush();
+    const exportPosts = () => posts.filter((p) => p.includes('"export"')).length;
+    expect(exportPosts()).toBe(1); // second request queued, not sent
+    dispatch({ event: 'export', format: 'xmlsvg', data: 'data:image/svg+xml;base64,YQ==' });
+    await flush();
+    expect(writes).toHaveLength(1);
+    expect(exportPosts()).toBe(2); // queued request flushed after the reply
+    dispatch({ event: 'export', format: 'xmlsvg', data: 'data:image/svg+xml;base64,Yg==' });
+    await flush();
+    expect(writes).toHaveLength(2);
+  });
+});

--- a/tests/dualFormat.test.ts
+++ b/tests/dualFormat.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   base64ToBytes, buildInitialPng, buildInitialSvg, decodeDataUri,
   dualFormatOf, extractXmlFromPng, extractXmlFromSvg,
+  replaceXmlInPng, replaceXmlInSvg,
 } from '../src/model/dualFormat';
 
 const XML = '<mxfile><diagram id="0" name="Page-1">A &amp; B "quoted" <x/></diagram></mxfile>';
@@ -31,6 +32,14 @@ describe('SVG embedding', () => {
     expect(extractXmlFromSvg('<svg xmlns="http://www.w3.org/2000/svg"/>')).toBeNull();
     expect(extractXmlFromSvg('not xml at all')).toBeNull();
   });
+
+  it('replaceXmlInSvg swaps the content attribute, keeping the rest of the body', () => {
+    const svg = buildInitialSvg(XML).replace('</svg>', '<rect width="5"/></svg>');
+    const next = replaceXmlInSvg(svg, '<mxfile>v2</mxfile>')!;
+    expect(extractXmlFromSvg(next)).toBe('<mxfile>v2</mxfile>');
+    expect(next).toContain('<rect');
+    expect(replaceXmlInSvg('plain text', '<x/>')).toBeNull();
+  });
 });
 
 describe('PNG embedding', () => {
@@ -45,6 +54,15 @@ describe('PNG embedding', () => {
     expect(Array.from(png.subarray(0, 8))).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     const tail = png.subarray(png.length - 8, png.length - 4);
     expect(String.fromCharCode(...tail)).toBe('IEND');
+  });
+
+  it('replaceXmlInPng swaps the chunk without accumulating duplicates', () => {
+    const once = replaceXmlInPng(buildInitialPng(XML), '<mxfile>v2</mxfile>')!;
+    const twice = replaceXmlInPng(once, '<mxfile>v3</mxfile>')!;
+    expect(extractXmlFromPng(twice)).toBe('<mxfile>v3</mxfile>');
+    // Same length as a single-embed PNG with the same payload: old chunk dropped.
+    expect(twice.length).toBe(buildInitialPng('<mxfile>v3</mxfile>').length);
+    expect(replaceXmlInPng(new Uint8Array([1, 2, 3]), '<x/>')).toBeNull();
   });
 
   it('returns null for a PNG without the mxfile chunk and for non-PNG bytes', () => {

--- a/tests/dualFormat.test.ts
+++ b/tests/dualFormat.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  base64ToBytes, buildInitialPng, buildInitialSvg, decodeDataUri,
+  dualFormatOf, extractXmlFromPng, extractXmlFromSvg,
+} from '../src/model/dualFormat';
+
+const XML = '<mxfile><diagram id="0" name="Page-1">A &amp; B "quoted" <x/></diagram></mxfile>';
+
+describe('dualFormatOf', () => {
+  it('detects both formats case-insensitively', () => {
+    expect(dualFormatOf('a.drawio.svg')).toBe('svg');
+    expect(dualFormatOf('dir/b.DRAWIO.PNG')).toBe('png');
+  });
+
+  it('rejects plain .drawio, bare images, and inner-only matches', () => {
+    expect(dualFormatOf('a.drawio')).toBeNull();
+    expect(dualFormatOf('a.svg')).toBeNull();
+    expect(dualFormatOf('a.png')).toBeNull();
+    expect(dualFormatOf('a.drawio.svg.md')).toBeNull();
+    expect(dualFormatOf('drawio.svg')).toBeNull(); // no stem before ".drawio"? — suffix match is enough
+  });
+});
+
+describe('SVG embedding', () => {
+  it('round-trips XML through the content attribute, preserving entities', () => {
+    const svg = buildInitialSvg(XML);
+    expect(extractXmlFromSvg(svg)).toBe(XML);
+  });
+
+  it('returns null for an SVG without embedded content and for non-SVG text', () => {
+    expect(extractXmlFromSvg('<svg xmlns="http://www.w3.org/2000/svg"/>')).toBeNull();
+    expect(extractXmlFromSvg('not xml at all')).toBeNull();
+  });
+});
+
+describe('PNG embedding', () => {
+  it('round-trips XML through a tEXt chunk', () => {
+    const png = buildInitialPng(XML);
+    expect(extractXmlFromPng(png)).toBe(XML);
+    expect(extractXmlFromPng(png.buffer as ArrayBuffer)).toBe(XML);
+  });
+
+  it('keeps the PNG structurally valid: signature intact, tEXt before IEND', () => {
+    const png = buildInitialPng(XML);
+    expect(Array.from(png.subarray(0, 8))).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const tail = png.subarray(png.length - 8, png.length - 4);
+    expect(String.fromCharCode(...tail)).toBe('IEND');
+  });
+
+  it('returns null for a PNG without the mxfile chunk and for non-PNG bytes', () => {
+    expect(extractXmlFromPng(base64ToBytes(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+    ))).toBeNull();
+    expect(extractXmlFromPng(new Uint8Array([1, 2, 3]))).toBeNull();
+  });
+});
+
+describe('decodeDataUri', () => {
+  it('decodes base64 payloads to bytes', () => {
+    const uri = `data:image/png;base64,${btoa('hello')}`;
+    expect(new TextDecoder().decode(decodeDataUri(uri))).toBe('hello');
+  });
+
+  it('decodes percent-encoded payloads', () => {
+    const uri = `data:image/svg+xml,${encodeURIComponent('<svg a="1"/>')}`;
+    expect(new TextDecoder().decode(decodeDataUri(uri))).toBe('<svg a="1"/>');
+  });
+
+  it('throws on non-data URIs', () => {
+    expect(() => decodeDataUri('https://example.com/x.png')).toThrow();
+  });
+});

--- a/tests/dualFormatFileSource.test.ts
+++ b/tests/dualFormatFileSource.test.ts
@@ -68,9 +68,18 @@ describe('DualFormatFileSource (svg)', () => {
     expect(box.text).toBe(exported);
   });
 
-  it('refuses plain XML writes', async () => {
-    const { app } = makeApp({ text: '' });
-    await expect(new DualFormatFileSource(app, svgFile, 'svg').write()).rejects.toThrow();
+  it('write() falls back to swapping only the embedded XML, keeping the image body', async () => {
+    const { app, box } = makeApp({ text: buildInitialSvg(XML) });
+    const src = new DualFormatFileSource(app, svgFile, 'svg');
+    await src.write('<mxfile>fallback</mxfile>');
+    expect(await src.read()).toBe('<mxfile>fallback</mxfile>');
+    expect(box.text).toContain('<svg'); // still an SVG, not a bare XML body
+  });
+
+  it('write() refuses to clobber a non-SVG body', async () => {
+    const { app } = makeApp({ text: 'not an svg' });
+    await expect(new DualFormatFileSource(app, svgFile, 'svg').write('<x/>'))
+      .rejects.toThrow(/not a valid SVG/);
   });
 });
 
@@ -101,5 +110,18 @@ describe('DualFormatFileSource (png)', () => {
     await new DualFormatFileSource(app, pngFile, 'png')
       .writeExport(`data:image/png;base64,${btoa(bin)}`);
     expect(Array.from(box.bytes)).toEqual(Array.from(next));
+  });
+
+  it('write() falls back to swapping the embedded XML inside the existing PNG', async () => {
+    const { app } = makeApp({ bytes: buildInitialPng(XML) });
+    const src = new DualFormatFileSource(app, pngFile, 'png');
+    await src.write('<mxfile>fallback</mxfile>');
+    expect(await src.read()).toBe('<mxfile>fallback</mxfile>');
+  });
+
+  it('write() refuses to clobber non-PNG bytes', async () => {
+    const { app } = makeApp({ bytes: new Uint8Array([1, 2, 3, 4]) });
+    await expect(new DualFormatFileSource(app, pngFile, 'png').write('<x/>'))
+      .rejects.toThrow(/not a valid PNG/);
   });
 });

--- a/tests/dualFormatFileSource.test.ts
+++ b/tests/dualFormatFileSource.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { DualFormatFileSource } from '../src/file/DualFormatFileSource';
+import { buildInitialPng, buildInitialSvg } from '../src/model/dualFormat';
+import { EMPTY_DIAGRAM } from '../src/constants';
+import { isExportingSource } from '../src/model/DrawioSource';
+
+const XML = '<mxfile><diagram id="0" name="P">x</diagram></mxfile>';
+
+function makeApp(initial: { text?: string; bytes?: Uint8Array }) {
+  const box = { text: initial.text ?? '', bytes: initial.bytes ?? new Uint8Array() };
+  const app = {
+    vault: {
+      read: async () => box.text,
+      readBinary: async () => {
+        const buf = new ArrayBuffer(box.bytes.byteLength);
+        new Uint8Array(buf).set(box.bytes);
+        return buf;
+      },
+      modify: async (_f: unknown, data: string) => { box.text = data; },
+      modifyBinary: async (_f: unknown, data: ArrayBuffer) => { box.bytes = new Uint8Array(data); },
+    },
+  } as unknown as import('obsidian').App;
+  return { app, box };
+}
+
+const svgFile = Object.assign(new TFile(), {
+  basename: 'flow.drawio', name: 'flow.drawio.svg', path: 'flow.drawio.svg',
+});
+const pngFile = Object.assign(new TFile(), {
+  basename: 'flow.drawio', name: 'flow.drawio.png', path: 'flow.drawio.png',
+});
+
+describe('DualFormatFileSource (svg)', () => {
+  it('is an ExportingSource requesting xmlsvg', () => {
+    const { app } = makeApp({ text: '' });
+    const src = new DualFormatFileSource(app, svgFile, 'svg');
+    expect(isExportingSource(src)).toBe(true);
+    expect(src.exportFormat()).toBe('xmlsvg');
+  });
+
+  it('titles without the inner .drawio suffix', () => {
+    const { app } = makeApp({ text: '' });
+    expect(new DualFormatFileSource(app, svgFile, 'svg').title()).toBe('flow');
+  });
+
+  it('reads the embedded XML back out of the SVG body', async () => {
+    const { app } = makeApp({ text: buildInitialSvg(XML) });
+    expect(await new DualFormatFileSource(app, svgFile, 'svg').read()).toBe(XML);
+  });
+
+  it('treats an empty file as a new empty diagram', async () => {
+    const { app } = makeApp({ text: '  ' });
+    expect(await new DualFormatFileSource(app, svgFile, 'svg').read()).toBe(EMPTY_DIAGRAM);
+  });
+
+  it('rejects an SVG without an embedded diagram instead of clobbering it', async () => {
+    const { app } = makeApp({ text: '<svg xmlns="http://www.w3.org/2000/svg"/>' });
+    await expect(new DualFormatFileSource(app, svgFile, 'svg').read())
+      .rejects.toThrow(/no embedded drawio diagram/);
+  });
+
+  it('persists an exported data URI as the new text body', async () => {
+    const { app, box } = makeApp({ text: buildInitialSvg(XML) });
+    const exported = buildInitialSvg('<mxfile>v2</mxfile>');
+    const uri = `data:image/svg+xml;base64,${btoa(exported)}`;
+    await new DualFormatFileSource(app, svgFile, 'svg').writeExport(uri);
+    expect(box.text).toBe(exported);
+  });
+
+  it('refuses plain XML writes', async () => {
+    const { app } = makeApp({ text: '' });
+    await expect(new DualFormatFileSource(app, svgFile, 'svg').write()).rejects.toThrow();
+  });
+});
+
+describe('DualFormatFileSource (png)', () => {
+  it('requests xmlpng and reads embedded XML from the binary body', async () => {
+    const { app } = makeApp({ bytes: buildInitialPng(XML) });
+    const src = new DualFormatFileSource(app, pngFile, 'png');
+    expect(src.exportFormat()).toBe('xmlpng');
+    expect(await src.read()).toBe(XML);
+  });
+
+  it('treats an empty file as a new empty diagram', async () => {
+    const { app } = makeApp({});
+    expect(await new DualFormatFileSource(app, pngFile, 'png').read()).toBe(EMPTY_DIAGRAM);
+  });
+
+  it('rejects a PNG without an embedded diagram', async () => {
+    const { app } = makeApp({ bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0, 0, 0, 0, 1]) });
+    await expect(new DualFormatFileSource(app, pngFile, 'png').read())
+      .rejects.toThrow(/no embedded drawio diagram/);
+  });
+
+  it('persists an exported data URI as the new binary body', async () => {
+    const { app, box } = makeApp({ bytes: buildInitialPng(XML) });
+    const next = buildInitialPng('<mxfile>v2</mxfile>');
+    let bin = '';
+    for (const b of next) bin += String.fromCharCode(b);
+    await new DualFormatFileSource(app, pngFile, 'png')
+      .writeExport(`data:image/png;base64,${btoa(bin)}`);
+    expect(Array.from(box.bytes)).toEqual(Array.from(next));
+  });
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -47,6 +47,7 @@ describe('DEFAULT_SETTINGS', () => {
         'drawioMode',
         'followObsidianTheme',
         'newDiagramFolder',
+        'newDiagramFormat',
         'newDiagramLocation',
         'previewAlignment',
         'previewClickAction',


### PR DESCRIPTION
## Summary

Adds first-class support for **dual-format diagram files** — `*.drawio.svg` / `*.drawio.png`, the format the VS Code drawio extension popularized: the file body is a standard SVG/PNG image with the diagram XML embedded inside (SVG: root `content` attribute; PNG: `tEXt` chunk, keyword `mxfile`). The files display as plain images everywhere — GitHub, external tools, and Obsidian's own image view and embeds — while staying fully editable in this plugin.

## Design (option B of the researched alternatives)

Deliberately does **not** register views for the `svg`/`png` extensions (extension registration is single-segment; taking over `svg`/`png` would hijack every image in the vault and conflict with the core image view). Instead:

- **Previews: zero code.** Obsidian renders dual-format files natively (image view, `![[...]]` embeds), desktop and mobile alike.
- **Editing entry points (desktop):** file context menu **Edit drawio diagram** + command **Edit diagram in the current image file** → the existing modal editor.
- **Save pipeline:** for dual-format sources the editor answers `save`/`autosave` with an `export` request (`xmlsvg`/`xmlpng`) and persists the returned data URI — image and diagram never drift apart. Overlapping autosaves coalesce into one trailing re-export; exit-on-save waits for the export to land.
- **Creation:** new **New diagram format** setting (`.drawio` default, unchanged behavior); dual-format creations seed a minimal valid image (PNG built with a hand-rolled `tEXt`+CRC32 chunk writer, no dependency) and open the modal editor.

## Mobile safety

`src/model/dualFormat.ts` is pure data transformation (DOMParser + DataView) — no `node:*`, no lookbehind/named-group/\p{} regex literals, loadable everywhere. Entry points stay inside `registerDesktopFeatures`. Binary Vault APIs used (`createBinary`/`readBinary`/`modifyBinary`) are all `@since 0.9.7`, far below `minAppVersion` 1.4.0.

## Tests

32 new tests: format detection, SVG/PNG embed round-trips (incl. PNG chunk-structure validity), data-URI decoding, source read/save semantics (incl. refusing to clobber a non-drawio image), and the editor's export round-trip (request-on-save, persist-on-export, exit sequencing, autosave coalescing). Full suite: 244/245 — the one failure is `portDetector`'s pre-existing WSL2-only port collision, fixed independently in #10; will disappear on rebase after #10 merges.

## Follow-ups (not in this PR)

- Click-to-edit hot zone on dual-format embeds (needs a Reading-view post-processor; entry points above cover the workflow meanwhile).
- CHANGELOG entry lands with the release that ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)