### PR TITLE
feat: export diagrams as plain SVG/PNG files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ All render as previews in both editing and reading views, and every edit autosav
 
 **Converting between code blocks and files:** two palette commands switch a diagram between its two source forms (they work on mobile too). **Extract diagram code block to file** — with the cursor inside a `` ```drawio `` block — moves the block's XML into a new `<note name> diagram.drawio` file next to the note (numbered `2`, `3`, … if that name is taken) and replaces the block with an embed. **Convert diagram embed to code block** — with the cursor on a line containing a `![[….drawio]]` embed — replaces the embed with a `` ```drawio `` block holding the file's XML; the file itself is kept, and any `#Page-…` or `|alias` part of the link is dropped.
 
+**Exporting plain images (desktop):** the **Export diagram as SVG** and **Export diagram as PNG** commands — also on the context menu of `.drawio` and `.drawio.svg`/`.drawio.png` files — write a plain `.svg`/`.png` image of the diagram (without the embedded diagram data) next to the source file, numbered `2`, `3`, … if the name is taken.
+
 ### Platform support
 
 | Feature | Desktop | Tablet | Phone |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,6 +46,8 @@
 
 **代码块与文件互转：** 命令面板提供两个命令，在图表的两种存放形式之间切换（移动端同样可用）。**Extract diagram code block to file** —— 光标位于 `` ```drawio `` 代码块内时 —— 会把块内 XML 移入笔记同文件夹下新建的 `<笔记名> diagram.drawio` 文件（重名时依次编号 `2`、`3`……），并把代码块替换为嵌入。**Convert diagram embed to code block** —— 光标所在行含 `![[….drawio]]` 嵌入时 —— 会把嵌入替换为包含该文件 XML 的 `` ```drawio `` 代码块；文件本身保留，链接上的 `#Page-…` 或 `|别名` 部分会被丢弃。
 
+**导出为普通图片（桌面端）：** **Export diagram as SVG** 与 **Export diagram as PNG** 命令 —— 也出现在 `.drawio` 及 `.drawio.svg`/`.drawio.png` 文件的右键菜单中 —— 会把图表导出为不含内嵌图表数据的普通 `.svg`/`.png` 图片，写入源文件所在文件夹（重名时依次编号 `2`、`3`……）。
+
 ### 平台支持
 
 | 功能 | 桌面 | 平板 | 手机 |

--- a/src/desktop/exportDiagram.ts
+++ b/src/desktop/exportDiagram.ts
@@ -1,0 +1,95 @@
+import { App, Notice, TFile, Vault } from 'obsidian';
+import { DRAWIO_FILE_EXT } from '../constants';
+import type DrawioPlugin from '../main';
+import type { DrawioSource } from '../model/DrawioSource';
+import { DualFormatFileSource } from '../file/DualFormatFileSource';
+import { FileSource } from '../file/FileSource';
+import { decodeDataUri, dualFormatOf } from '../model/dualFormat';
+import { OfflineEditorNotInstalledError } from '../model/errors';
+import { uniquePath } from '../model/uniquePath';
+import { exportDiagramXml, PlainExportFormat } from '../editor/HeadlessExporter';
+
+/** Whether the export commands can act on this file: a standalone `.drawio`
+ * file or a dual-format `.drawio.svg` / `.drawio.png` image. */
+export function isExportableDiagram(file: TFile): boolean {
+  return file.extension.toLowerCase() === DRAWIO_FILE_EXT || dualFormatOf(file.path) !== null;
+}
+
+/** Diagram suffixes stripped from the source name when deriving the export
+ * name — longest first so `a.drawio.svg` becomes `a`, not `a.drawio`. */
+const DIAGRAM_SUFFIXES = ['.drawio.svg', '.drawio.png', '.drawio'];
+
+/**
+ * The `<source basename minus diagram suffix>.<format>` path in the source
+ * file's folder, numbered ` 2`, ` 3`, … when taken (same scheme as
+ * uniqueDiagramPath). Pure — `exists` abstracts the vault lookup.
+ */
+export function exportTargetPath(
+  sourcePath: string,
+  format: PlainExportFormat,
+  exists: (path: string) => boolean,
+): string {
+  const slash = sourcePath.lastIndexOf('/');
+  const folder = sourcePath.slice(0, slash + 1); // '' at the vault root
+  const name = sourcePath.slice(slash + 1);
+  const lower = name.toLowerCase();
+  const suffix = DIAGRAM_SUFFIXES.find((s) => lower.endsWith(s));
+  const base = suffix ? name.slice(0, -suffix.length) : name;
+  return uniquePath(folder + base, `.${format}`, exists);
+}
+
+/** Persist an exported `data:` URI: SVG as a text file, PNG as binary. */
+export async function writeExportedFile(
+  vault: Vault,
+  path: string,
+  format: PlainExportFormat,
+  dataUri: string,
+): Promise<TFile> {
+  const bytes = decodeDataUri(dataUri);
+  if (format === 'svg') {
+    return vault.create(path, new TextDecoder().decode(bytes));
+  }
+  // createBinary wants a plain ArrayBuffer; copy so no view offset or shared
+  // underlying buffer leaks into the write.
+  const copy = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(copy).set(bytes);
+  return vault.createBinary(path, copy);
+}
+
+/** The edit-target abstraction already knows how to read each diagram kind:
+ * plain `.drawio` files hold bare XML, dual-format images embed it. */
+function sourceFor(app: App, file: TFile): DrawioSource | null {
+  const dual = dualFormatOf(file.path);
+  if (dual) return new DualFormatFileSource(app, file, dual);
+  if (file.extension.toLowerCase() === DRAWIO_FILE_EXT) return new FileSource(app, file);
+  return null;
+}
+
+/**
+ * Full export flow: read the diagram XML from `file`, render it to a plain
+ * SVG/PNG through a hidden drawio iframe (see HeadlessExporter), and write
+ * the image next to the source. Every failure surfaces as a Notice; nothing
+ * is written on failure.
+ */
+export async function exportDiagramToFile(
+  plugin: DrawioPlugin,
+  file: TFile,
+  format: PlainExportFormat,
+): Promise<void> {
+  const source = sourceFor(plugin.app, file);
+  if (!source) return;
+  try {
+    const xml = await source.read();
+    const dataUri = await exportDiagramXml(xml, format, plugin.editorDeps());
+    const vault = plugin.app.vault;
+    const path = exportTargetPath(file.path, format,
+      (p) => vault.getAbstractFileByPath(p) !== null);
+    const created = await writeExportedFile(vault, path, format, dataUri);
+    new Notice(`Drawio: exported to "${created.path}"`);
+  } catch (err) {
+    console.error('[drawio] export failed:', err);
+    new Notice(err instanceof OfflineEditorNotInstalledError
+      ? err.message
+      : `Drawio: could not export the diagram — ${String(err)}`);
+  }
+}

--- a/src/desktop/registerDesktopFeatures.ts
+++ b/src/desktop/registerDesktopFeatures.ts
@@ -4,6 +4,7 @@ import { ServerManager } from '../server/ServerManager';
 import { createNewDiagram } from '../file/createDiagram';
 import { DualFormatFileSource } from '../file/DualFormatFileSource';
 import { dualFormatOf } from '../model/dualFormat';
+import { exportDiagramToFile, isExportableDiagram } from './exportDiagram';
 import type DrawioPlugin from '../main';
 
 /**
@@ -40,7 +41,8 @@ export async function registerDesktopFeatures(plugin: DrawioPlugin): Promise<voi
 
   // "New drawio diagram" on folder context menus, creating in that folder;
   // "Edit drawio diagram" on dual-format image files (which open in
-  // Obsidian's own image view, so they need an explicit editor entry).
+  // Obsidian's own image view, so they need an explicit editor entry);
+  // "Export diagram as SVG/PNG" on every diagram file.
   plugin.registerEvent(plugin.app.workspace.on('file-menu', (menu, file) => {
     if (file instanceof TFolder) {
       menu.addItem((item) => item
@@ -57,6 +59,14 @@ export async function registerDesktopFeatures(plugin: DrawioPlugin): Promise<voi
             plugin.openEditor(new DualFormatFileSource(plugin.app, file, format));
           }));
       }
+      if (isExportableDiagram(file)) {
+        for (const target of ['svg', 'png'] as const) {
+          menu.addItem((item) => item
+            .setTitle(`Export diagram as ${target.toUpperCase()}`)
+            .setIcon('download')
+            .onClick(() => { void exportDiagramToFile(plugin, file, target); }));
+        }
+      }
     }
   }));
 
@@ -71,6 +81,21 @@ export async function registerDesktopFeatures(plugin: DrawioPlugin): Promise<voi
       return true;
     },
   });
+
+  // Plain-image export of the active diagram file (.drawio or dual-format):
+  // a standalone .svg/.png — no embedded diagram data — next to the source.
+  for (const format of ['svg', 'png'] as const) {
+    plugin.addCommand({
+      id: `export-diagram-${format}`,
+      name: `Export diagram as ${format.toUpperCase()}`,
+      checkCallback: (checking) => {
+        const file = plugin.app.workspace.getActiveFile();
+        if (!file || !isExportableDiagram(file)) return false;
+        if (!checking) void exportDiagramToFile(plugin, file, format);
+        return true;
+      },
+    });
+  }
 
   // Lifecycle detection: offline mode selected but the webapp isn't installed.
   // One notice per plugin load — the settings tab carries the actual installer.

--- a/src/editor/HeadlessExporter.ts
+++ b/src/editor/HeadlessExporter.ts
@@ -1,0 +1,86 @@
+import { buildEmbedQuery } from '../constants';
+import {
+  buildConfigureMessage, buildExportMessage, buildLoadMessage, parseDrawioEvent,
+} from './embedMessages';
+import type { DrawioEditorDeps } from './DrawioEditor';
+
+/** Plain image export formats — unlike the dual-format `xmlsvg`/`xmlpng`
+ * bodies, the output carries no embedded diagram XML. */
+export type PlainExportFormat = 'svg' | 'png';
+
+export interface HeadlessExportOptions {
+  /** How long to wait for drawio's export reply before rejecting
+   * (tests shrink this; defaults to 30 s). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * One-shot, invisible drawio export: mounts an off-screen embed-mode iframe on
+ * `activeDocument.body`, drives the postMessage handshake (configure → init →
+ * load → export), and resolves with the exported image as a `data:` URI.
+ * The container, the message listener, the timer, and the server pin are all
+ * torn down whether the export succeeds, fails, or times out.
+ *
+ * Always a main-window flow (the export commands and menu items run there), so
+ * unlike DrawioEditor it needs none of the popout rebind/eval-post machinery.
+ */
+export async function exportDiagramXml(
+  xml: string,
+  format: PlainExportFormat,
+  deps: DrawioEditorDeps,
+  options: HeadlessExportOptions = {},
+): Promise<string> {
+  const base = await deps.resolveBaseUrl();
+  const origin = new URL(base).origin;
+  const q = buildEmbedQuery({ dark: false, libraries: false });
+  const url = `${base}${base.includes('?') ? '&' : '?'}${q}`;
+
+  deps.acquireServer();
+  const container = activeDocument.body.createDiv({ cls: 'drawio-headless-exporter' });
+  const win = container.ownerDocument.defaultView ?? window;
+  const iframe = container.createEl('iframe', { cls: 'drawio-iframe' });
+
+  let timer: number | null = null;
+  let onMessage: ((e: MessageEvent) => void) | null = null;
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      const post = (message: string) => {
+        iframe.contentWindow?.postMessage(message, origin === 'null' ? '*' : origin);
+      };
+      onMessage = (e: MessageEvent) => {
+        if (e.source !== iframe.contentWindow) return;
+        if (origin !== 'null' && e.origin !== origin) return;
+        const ev = parseDrawioEvent(e.data);
+        if (!ev) return;
+        switch (ev.event) {
+          case 'configure':
+            post(buildConfigureMessage());
+            break;
+          case 'init':
+            post(buildLoadMessage(xml, { dark: false }));
+            break;
+          case 'load':
+            // The diagram is in; ask for the plain image.
+            post(buildExportMessage(format));
+            break;
+          case 'export':
+            resolve((ev as { data: string }).data);
+            break;
+        }
+      };
+      win.addEventListener('message', onMessage);
+      timer = window.setTimeout(
+        () => reject(new Error('timed out waiting for the drawio export')),
+        options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      );
+      iframe.setAttribute('src', url);
+    });
+  } finally {
+    if (timer !== null) window.clearTimeout(timer);
+    if (onMessage) win.removeEventListener('message', onMessage);
+    container.remove();
+    deps.releaseServer();
+  }
+}

--- a/src/model/blockFileConvert.ts
+++ b/src/model/blockFileConvert.ts
@@ -1,5 +1,6 @@
 import { locateDrawioBlockAtLine } from '../codeblock/locateBlock';
 import { EMPTY_DIAGRAM } from '../constants';
+import { uniquePath } from './uniquePath';
 
 /** 0-based editor position, structurally compatible with Obsidian's EditorPosition. */
 export interface Pos { line: number; ch: number }
@@ -54,11 +55,7 @@ export function uniqueDiagramPath(
   noteBasename: string,
   exists: (path: string) => boolean,
 ): string {
-  const prefix = (folder ? `${folder}/` : '') + `${noteBasename} diagram`;
-  for (let n = 1; ; n++) {
-    const path = `${prefix}${n === 1 ? '' : ` ${n}`}.drawio`;
-    if (!exists(path)) return path;
-  }
+  return uniquePath((folder ? `${folder}/` : '') + `${noteBasename} diagram`, '.drawio', exists);
 }
 
 // --------------------------------------------------------------------------

--- a/src/model/uniquePath.ts
+++ b/src/model/uniquePath.ts
@@ -1,0 +1,16 @@
+/**
+ * First free `<prefix><ext>` path; when taken, `<prefix> 2<ext>`, ` 3`, …
+ * The single numbering scheme for every file this plugin creates
+ * (extracted diagrams, exported images). `exists` abstracts the vault
+ * lookup so this stays pure (and mobile-safe).
+ */
+export function uniquePath(
+  prefix: string,
+  ext: string,
+  exists: (path: string) => boolean,
+): string {
+  for (let n = 1; ; n++) {
+    const path = `${prefix}${n === 1 ? '' : ` ${n}`}${ext}`;
+    if (!exists(path)) return path;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -58,6 +58,20 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
 .drawio-modal .modal-content { height: 100%; padding: 0; }
 .drawio-iframe { width: 100%; height: 100%; border: none; display: block; }
 
+/* ---- Headless export (HeadlessExporter) ---- */
+/* Off-screen host for the one-shot export iframe: kept rendered — not
+   display:none — so drawio can lay out and rasterize, but never visible or
+   interactive. */
+.drawio-headless-exporter {
+  position: fixed;
+  top: -10000px;
+  left: -10000px;
+  width: 800px;
+  height: 600px;
+  overflow: hidden;
+  pointer-events: none;
+}
+
 /* ---- Inline editor in the tab (.drawio files, Excalidraw-style) ---- */
 .drawio-file-view { height: 100%; padding: 0; }
 .drawio-file-view .drawio-iframe { width: 100%; height: 100%; }

--- a/tests/exportDiagram.test.ts
+++ b/tests/exportDiagram.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TFile } from 'obsidian';
+import type { Vault } from 'obsidian';
+import {
+  exportTargetPath, isExportableDiagram, writeExportedFile,
+} from '../src/desktop/exportDiagram';
+
+function tfile(path: string): TFile {
+  const f = new TFile();
+  f.path = path;
+  const name = path.split('/').pop() ?? path;
+  const dot = name.lastIndexOf('.');
+  f.extension = dot < 0 ? '' : name.slice(dot + 1);
+  f.basename = dot < 0 ? name : name.slice(0, dot);
+  return f;
+}
+
+const none = () => false;
+
+describe('isExportableDiagram', () => {
+  it('accepts .drawio and both dual-format extensions', () => {
+    expect(isExportableDiagram(tfile('a.drawio'))).toBe(true);
+    expect(isExportableDiagram(tfile('sub/b.drawio.svg'))).toBe(true);
+    expect(isExportableDiagram(tfile('sub/c.drawio.png'))).toBe(true);
+  });
+
+  it('rejects everything else', () => {
+    expect(isExportableDiagram(tfile('a.svg'))).toBe(false);
+    expect(isExportableDiagram(tfile('a.png'))).toBe(false);
+    expect(isExportableDiagram(tfile('note.md'))).toBe(false);
+  });
+});
+
+describe('exportTargetPath', () => {
+  it('drops the .drawio suffix and appends the export extension', () => {
+    expect(exportTargetPath('notes/a.drawio', 'svg', none)).toBe('notes/a.svg');
+    expect(exportTargetPath('notes/a.drawio', 'png', none)).toBe('notes/a.png');
+  });
+
+  it('drops the full dual-format suffix', () => {
+    expect(exportTargetPath('x/b.drawio.svg', 'svg', none)).toBe('x/b.svg');
+    expect(exportTargetPath('x/b.drawio.png', 'png', none)).toBe('x/b.png');
+    expect(exportTargetPath('x/b.drawio.png', 'svg', none)).toBe('x/b.svg');
+  });
+
+  it('works at the vault root and matches suffixes case-insensitively', () => {
+    expect(exportTargetPath('a.drawio', 'svg', none)).toBe('a.svg');
+    expect(exportTargetPath('A.DRAWIO', 'png', none)).toBe('A.png');
+  });
+
+  it('numbers the name 2, 3, … when taken (same scheme as uniqueDiagramPath)', () => {
+    const taken = new Set(['d/a.svg', 'd/a 2.svg']);
+    expect(exportTargetPath('d/a.drawio', 'svg', (p) => taken.has(p))).toBe('d/a 3.svg');
+  });
+});
+
+describe('writeExportedFile', () => {
+  function fakeVault() {
+    return {
+      create: vi.fn(async (path: string, _data: string) => tfile(path)),
+      createBinary: vi.fn(async (path: string, _data: ArrayBuffer) => tfile(path)),
+    };
+  }
+
+  it('writes SVG exports as decoded text via vault.create', async () => {
+    const vault = fakeVault();
+    const uri = `data:image/svg+xml;base64,${btoa('<svg>x</svg>')}`;
+    const created = await writeExportedFile(vault as unknown as Vault, 'a.svg', 'svg', uri);
+    expect(vault.create).toHaveBeenCalledWith('a.svg', '<svg>x</svg>');
+    expect(vault.createBinary).not.toHaveBeenCalled();
+    expect(created.path).toBe('a.svg');
+  });
+
+  it('writes PNG exports as an independent ArrayBuffer via vault.createBinary', async () => {
+    const vault = fakeVault();
+    const uri = `data:image/png;base64,${btoa(String.fromCharCode(1, 2, 3))}`;
+    await writeExportedFile(vault as unknown as Vault, 'a.png', 'png', uri);
+    expect(vault.create).not.toHaveBeenCalled();
+    const buf = vault.createBinary.mock.calls[0]![1] as ArrayBuffer;
+    expect(buf).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(buf))).toEqual([1, 2, 3]);
+  });
+
+  it('rejects on a malformed data URI without writing anything', async () => {
+    const vault = fakeVault();
+    await expect(writeExportedFile(vault as unknown as Vault, 'a.svg', 'svg', 'nonsense'))
+      .rejects.toThrow(/data: URI/);
+    expect(vault.create).not.toHaveBeenCalled();
+    expect(vault.createBinary).not.toHaveBeenCalled();
+  });
+});

--- a/tests/headlessExporter.test.ts
+++ b/tests/headlessExporter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { exportDiagramXml, PlainExportFormat } from '../src/editor/HeadlessExporter';
+import type { DrawioEditorDeps } from '../src/editor/DrawioEditor';
+
+const ORIGIN = 'http://127.0.0.1:1234';
+const XML = '<mxfile><diagram/></mxfile>';
+const SVG_URI = 'data:image/svg+xml;base64,PHN2Zy8+';
+
+function makeDeps(): DrawioEditorDeps {
+  return {
+    resolveBaseUrl: async () => `${ORIGIN}/index.html`,
+    isDark: () => false,
+    showLibraries: () => true,
+    acquireServer: vi.fn(),
+    releaseServer: vi.fn(),
+  };
+}
+
+async function flush() {
+  await new Promise((r) => window.setTimeout(r, 0));
+}
+
+/** Kick off an export, wait for the iframe mount, and wire the same
+ * dispatch/postMessage-spy plumbing as tests/drawioEditorExport.test.ts. */
+async function start(format: PlainExportFormat, deps: DrawioEditorDeps, timeoutMs = 5000) {
+  const promise = exportDiagramXml(XML, format, deps, { timeoutMs });
+  await flush(); // let resolveBaseUrl settle and the DOM mount
+  const iframe = document.querySelector<HTMLIFrameElement>('.drawio-headless-exporter iframe')!;
+  expect(iframe).not.toBeNull();
+  const posts: string[] = [];
+  vi.spyOn(iframe.contentWindow!, 'postMessage').mockImplementation((msg: unknown) => {
+    posts.push(msg as string);
+  });
+  const dispatch = (data: unknown, origin = ORIGIN, source: Window | null = iframe.contentWindow) => {
+    window.dispatchEvent(new MessageEvent('message', {
+      data: JSON.stringify(data), origin, source,
+    }));
+  };
+  return { promise, posts, dispatch };
+}
+
+function containers() {
+  return document.querySelectorAll('.drawio-headless-exporter');
+}
+
+describe('exportDiagramXml (headless drawio export)', () => {
+  afterEach(() => {
+    // Any leftover mount is a cleanup bug in the test at hand; don't let it
+    // leak into the next one.
+    containers().forEach((el) => el.remove());
+  });
+
+  it('drives configure → init → load → export and resolves with the data URI', async () => {
+    const deps = makeDeps();
+    const { promise, posts, dispatch } = await start('svg', deps);
+
+    dispatch({ event: 'configure' });
+    expect(posts).toContainEqual(JSON.stringify({ action: 'configure', config: { compressXml: false } }));
+
+    dispatch({ event: 'init' });
+    const load = posts.find((p) => p.includes('"action":"load"'));
+    expect(load).toBeDefined();
+    expect(JSON.parse(load!)).toMatchObject({ action: 'load', xml: XML });
+
+    dispatch({ event: 'load' });
+    expect(posts).toContainEqual(JSON.stringify({ action: 'export', format: 'svg' }));
+
+    dispatch({ event: 'export', format: 'svg', data: SVG_URI });
+    await expect(promise).resolves.toBe(SVG_URI);
+  });
+
+  it('requests the png format for png exports', async () => {
+    const deps = makeDeps();
+    const { promise, posts, dispatch } = await start('png', deps);
+    dispatch({ event: 'load' });
+    expect(posts).toContainEqual(JSON.stringify({ action: 'export', format: 'png' }));
+    dispatch({ event: 'export', format: 'png', data: 'data:image/png;base64,AA==' });
+    await expect(promise).resolves.toBe('data:image/png;base64,AA==');
+  });
+
+  it('cleans up the DOM, the listener, and the server pin after success', async () => {
+    const deps = makeDeps();
+    const { promise, posts, dispatch } = await start('svg', deps);
+    dispatch({ event: 'export', format: 'svg', data: SVG_URI });
+    await promise;
+
+    expect(containers()).toHaveLength(0);
+    expect(deps.acquireServer).toHaveBeenCalledTimes(1);
+    expect(deps.releaseServer).toHaveBeenCalledTimes(1);
+
+    // The message listener is gone: further protocol traffic posts nothing.
+    const before = posts.length;
+    dispatch({ event: 'configure' });
+    expect(posts).toHaveLength(before);
+  });
+
+  it('rejects after the timeout and still cleans up', async () => {
+    const deps = makeDeps();
+    const { promise } = await start('svg', deps, 30);
+    await expect(promise).rejects.toThrow(/timed out/);
+    expect(containers()).toHaveLength(0);
+    expect(deps.releaseServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores messages from the wrong origin or a foreign source', async () => {
+    const deps = makeDeps();
+    const { promise, posts, dispatch } = await start('svg', deps);
+
+    dispatch({ event: 'export', format: 'svg', data: SVG_URI }, 'http://evil.example');
+    dispatch({ event: 'export', format: 'svg', data: SVG_URI }, ORIGIN, window);
+    await flush();
+    expect(containers()).toHaveLength(1); // still pending — nothing accepted
+    expect(posts).toHaveLength(0);
+
+    dispatch({ event: 'export', format: 'svg', data: SVG_URI });
+    await expect(promise).resolves.toBe(SVG_URI);
+  });
+
+  it('propagates a resolveBaseUrl failure without touching the server or the DOM', async () => {
+    const deps = makeDeps();
+    deps.resolveBaseUrl = async () => { throw new Error('offline editor not installed'); };
+    await expect(exportDiagramXml(XML, 'svg', deps)).rejects.toThrow('offline editor not installed');
+    expect(containers()).toHaveLength(0);
+    expect(deps.acquireServer).not.toHaveBeenCalled();
+    expect(deps.releaseServer).not.toHaveBeenCalled();
+  });
+});

--- a/tests/registerDesktopFeatures.test.ts
+++ b/tests/registerDesktopFeatures.test.ts
@@ -5,7 +5,7 @@ vi.mock('obsidian', async (importOriginal) => {
   return { ...orig, Notice: vi.fn() };
 });
 
-import { FileSystemAdapter, Notice } from 'obsidian';
+import { FileSystemAdapter, Notice, TFile } from 'obsidian';
 import { registerDesktopFeatures } from '../src/desktop/registerDesktopFeatures';
 import type DrawioPlugin from '../src/main';
 
@@ -13,12 +13,24 @@ class FakeAdapter extends FileSystemAdapter {
   getBasePath(): string { return '/vault'; }
 }
 
+function tfile(path: string): TFile {
+  const f = new TFile();
+  f.path = path;
+  const name = path.split('/').pop() ?? path;
+  const dot = name.lastIndexOf('.');
+  f.extension = dot < 0 ? '' : name.slice(dot + 1);
+  f.basename = dot < 0 ? name : name.slice(0, dot);
+  return f;
+}
+
 function fakePlugin() {
-  const workspaceOn = vi.fn(() => ({}));
+  const workspaceOn = vi.fn(
+    (_name: string, _cb: (menu: unknown, file: unknown) => unknown) => ({}));
+  const getActiveFile = vi.fn<() => TFile | null>(() => null);
   const raw = {
     app: {
       vault: { adapter: new FakeAdapter() },
-      workspace: { on: workspaceOn },
+      workspace: { on: workspaceOn, getActiveFile },
     },
     manifest: { dir: 'drawio-editor' },
     settings: {
@@ -32,7 +44,33 @@ function fakePlugin() {
     registerEvent: vi.fn(),
     isWebappInstalled: vi.fn(async () => true),
   };
-  return { plugin: raw as unknown as DrawioPlugin, raw, workspaceOn };
+  return { plugin: raw as unknown as DrawioPlugin, raw, workspaceOn, getActiveFile };
+}
+
+interface RegisteredCommand {
+  id: string;
+  name: string;
+  checkCallback?: (checking: boolean) => boolean;
+}
+
+function registeredCommand(raw: { addCommand: ReturnType<typeof vi.fn> }, id: string) {
+  const cmd = raw.addCommand.mock.calls
+    .map((c) => c[0] as RegisteredCommand)
+    .find((c) => c.id === id);
+  expect(cmd).toBeDefined();
+  return cmd!;
+}
+
+/** Menu double: records item titles, ignores icons/clicks. */
+function fakeMenu() {
+  const titles: string[] = [];
+  const item = {
+    setTitle(t: string) { titles.push(t); return item; },
+    setIcon() { return item; },
+    onClick() { return item; },
+  };
+  const menu = { addItem: (cb: (i: typeof item) => unknown) => { cb(item); return menu; } };
+  return { menu, titles };
 }
 
 describe('registerDesktopFeatures', () => {
@@ -66,6 +104,51 @@ describe('registerDesktopFeatures', () => {
     await registerDesktopFeatures(plugin);
     expect(raw.registerEvent).toHaveBeenCalledTimes(1);
     expect(workspaceOn).toHaveBeenCalledWith('file-menu', expect.any(Function));
+  });
+
+  it('registers the two export commands', async () => {
+    const { plugin, raw } = fakePlugin();
+    await registerDesktopFeatures(plugin);
+    expect(raw.addCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'export-diagram-svg', name: 'Export diagram as SVG' }),
+    );
+    expect(raw.addCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'export-diagram-png', name: 'Export diagram as PNG' }),
+    );
+  });
+
+  it('export commands are available only when the active file is a diagram', async () => {
+    const { plugin, raw, getActiveFile } = fakePlugin();
+    await registerDesktopFeatures(plugin);
+    const check = registeredCommand(raw, 'export-diagram-svg').checkCallback!;
+
+    expect(check(true)).toBe(false); // no active file
+    getActiveFile.mockReturnValue(tfile('note.md'));
+    expect(check(true)).toBe(false);
+    getActiveFile.mockReturnValue(tfile('d/a.drawio'));
+    expect(check(true)).toBe(true);
+    getActiveFile.mockReturnValue(tfile('d/a.drawio.png'));
+    expect(check(true)).toBe(true);
+  });
+
+  it('file-menu offers both export items on diagram files, none on others', async () => {
+    const { plugin, workspaceOn } = fakePlugin();
+    await registerDesktopFeatures(plugin);
+    const handler = workspaceOn.mock.calls
+      .find((c) => c[0] === 'file-menu')![1] as (menu: unknown, file: unknown) => void;
+
+    const drawio = fakeMenu();
+    handler(drawio.menu, tfile('a.drawio'));
+    expect(drawio.titles).toEqual(['Export diagram as SVG', 'Export diagram as PNG']);
+
+    const dual = fakeMenu();
+    handler(dual.menu, tfile('a.drawio.svg'));
+    expect(dual.titles).toEqual(
+      ['Edit drawio diagram', 'Export diagram as SVG', 'Export diagram as PNG']);
+
+    const other = fakeMenu();
+    handler(other.menu, tfile('note.md'));
+    expect(other.titles).toEqual([]);
   });
 
   it('throws if the vault adapter is not a FileSystemAdapter', async () => {


### PR DESCRIPTION
## What

Two new desktop-only commands — **Export diagram as SVG** and **Export diagram as PNG** — plus matching items on the file context menu of `.drawio` and dual-format (`.drawio.svg` / `.drawio.png`) files.

## Behavior

- Available when the active (or right-clicked) file is a `.drawio` or `.drawio.svg`/`.drawio.png` diagram.
- Reads the diagram XML (`FileSource` for `.drawio`, `DualFormatFileSource` for dual-format images) and renders it through a hidden drawio embed iframe (`src/editor/HeadlessExporter.ts`): the standard `configure → init → load → export` postMessage handshake, resolving with the exported `data:` URI. 30 s timeout; the container, message listener, timer, and server pin are torn down whether the export succeeds, fails, or times out. Always a main-window flow, so no popout rebind/eval-post machinery is needed.
- The output is a **plain** image — no embedded diagram XML — written to the source file's folder as `<basename minus .drawio suffix>.svg`/`.png`, numbered ` 2`, ` 3`, … when the name is taken. The numbering reuses the existing `uniqueDiagramPath` scheme, generalized into `src/model/uniquePath.ts` (one scheme for extracted diagrams and exports, not a second system).
- A Notice reports the created file's path on success; every failure (missing offline editor, unreadable diagram, timeout) surfaces as a Notice and writes nothing.

## Constraints honored

- No `node:*`/`electron` imports outside `src/server/**`/`src/desktop/**` (HeadlessExporter has none at all); no `createElement('script')`; `activeDocument`/`window.setTimeout` in render paths; no lookbehind/named-group/`\p{}` regex literals.
- All Obsidian APIs used (`Vault.create` @0.9.7, `Vault.createBinary` @0.9.7, `getAbstractFileByPath` @0.11.11) are well under `minAppVersion` 1.4.0.
- README change mirrored in `README.zh-CN.md`.

## Tests

- `tests/headlessExporter.test.ts` — jsdom message round-trip (dispatch/postMessage-spy per `drawioEditorExport.test.ts`): full handshake success for svg and png, timeout rejection, DOM/listener/server-pin cleanup on success and failure, wrong-origin/foreign-source messages ignored, `resolveBaseUrl` failure propagation.
- `tests/exportDiagram.test.ts` — pure target-path naming (suffix stripping, root paths, case-insensitivity, ` 2`/` 3` numbering) and svg/png write branching (text `create` vs binary `createBinary` with an independent `ArrayBuffer`).
- `tests/registerDesktopFeatures.test.ts` — both commands registered, `checkCallback` gating by file type, file-menu items on diagram files only.

`npm test`: 302 passed (42 files). `npm run build`: clean (tsc + esbuild guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)