### PR TITLE
feat(preview): add interactive viewer and resizable height

### DIFF
--- a/src/codeblock/DrawioCodeBlock.ts
+++ b/src/codeblock/DrawioCodeBlock.ts
@@ -3,24 +3,30 @@ import { renderPreview } from '../preview/ViewerRenderer';
 import { renderPageControl } from '../preview/pageControl';
 import { addEditHint } from '../preview/editHint';
 import { resolveClickAction } from '../preview/clickAction';
+import { InteractiveViewerController } from '../preview/interactiveViewer';
+import {
+  readCodeBlockViewportHeight, writeCodeBlockViewportHeight,
+} from '../preview/viewportHeight';
 import { getDiagramPages, ensureMxfile } from '../model/xmlUtils';
 import { CodeBlockSource } from './CodeBlockSource';
 import type DrawioPlugin from '../main';
 
 export function registerDrawioCodeBlock(plugin: DrawioPlugin) {
-  plugin.registerMarkdownCodeBlockProcessor('drawio', (source, el, ctx) => {
-    renderCodeBlock(plugin, source, el, ctx);
-  });
+  plugin.registerMarkdownCodeBlockProcessor('drawio', (source, el, ctx) =>
+    renderCodeBlock(plugin, source, el, ctx));
 }
 
-function renderCodeBlock(
+async function renderCodeBlock(
   plugin: DrawioPlugin,
   source: string,
   el: HTMLElement,
   ctx: MarkdownPostProcessorContext,
-) {
-  const wrapper = el.createDiv({ cls: 'drawio-codeblock' });
+): Promise<void> {
   const action = resolveClickAction(plugin.settings.previewClickAction, 'codeblock');
+  const initialHeight = Platform.isDesktopApp && action.kind === 'interactive'
+    ? await readCodeBlockViewportHeight(plugin.app, ctx, el, source)
+    : null;
+  const wrapper = el.createDiv({ cls: 'drawio-codeblock' });
   wrapper.setAttribute('title', Platform.isDesktopApp ? action.title : 'Drawio diagram');
   wrapper.toggleClass('drawio-no-action', Platform.isDesktopApp && action.kind === 'none');
   const preview = wrapper.createDiv({ cls: 'drawio-preview' });
@@ -28,6 +34,7 @@ function renderCodeBlock(
   const wrapped = ensureMxfile(source);
   const pages = getDiagramPages(wrapped);
   let currentPage = 0;
+  let interactive: InteractiveViewerController | null = null;
   renderPreview(preview, source, { ...plugin.previewOpts(), page: currentPage });
 
   if (pages.length > 1) {
@@ -38,12 +45,30 @@ function renderCodeBlock(
       onPageChange: (page) => {
         currentPage = page;
         renderPreview(preview, source, { ...plugin.previewOpts(), page });
+        interactive?.bindSvg(preview.querySelector('svg'), { preserveViewportHeight: true });
       },
     });
   }
 
   if (Platform.isDesktopApp && action.hint) {
     addEditHint(wrapper, action.hint.label, action.hint.icon);
+  }
+
+  if (Platform.isDesktopApp) {
+    interactive = new InteractiveViewerController(wrapper, preview, {
+      isEnabled: () =>
+        resolveClickAction(plugin.settings.previewClickAction, 'codeblock').kind === 'interactive',
+      initialHeight: initialHeight ?? undefined,
+      onHeightCommit: (height) => {
+        void writeCodeBlockViewportHeight(plugin.app, ctx, el, source, height).then((written) => {
+          if (!written) new Notice('Drawio: could not save the viewer height for this code block.');
+        }).catch((err) => {
+          new Notice(`Drawio: could not save viewer height — ${String(err)}`);
+        });
+      },
+    });
+    interactive.bindSvg(preview.querySelector('svg'));
+    ctx.addChild(interactive);
   }
 
   // Click anywhere on the diagram (the centered hint shows on hover). The

--- a/src/codeblock/DrawioCodeBlock.ts
+++ b/src/codeblock/DrawioCodeBlock.ts
@@ -2,7 +2,7 @@ import { MarkdownPostProcessorContext, Notice, Platform } from 'obsidian';
 import { renderPreview } from '../preview/ViewerRenderer';
 import { renderPageControl } from '../preview/pageControl';
 import { addEditHint } from '../preview/editHint';
-import { resolveClickAction } from '../preview/clickAction';
+import { resolveClickAction, resolveEditButtonAction } from '../preview/clickAction';
 import { InteractiveViewerController } from '../preview/interactiveViewer';
 import {
   readCodeBlockViewportHeight, writeCodeBlockViewportHeight,
@@ -65,6 +65,12 @@ async function renderCodeBlock(
         }).catch((err) => {
           new Notice(`Drawio: could not save viewer height — ${String(err)}`);
         });
+      },
+      onEdit: () => {
+        const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'codeblock');
+        if (editAction.kind === 'editor') {
+          plugin.openEditor(new CodeBlockSource(plugin.app, ctx, el, source));
+        }
       },
     });
     interactive.bindSvg(preview.querySelector('svg'));

--- a/src/file/EmbedRenderer.ts
+++ b/src/file/EmbedRenderer.ts
@@ -2,7 +2,10 @@ import { MarkdownPostProcessorContext, MarkdownRenderChild, Notice, Platform, TF
 import { renderPreview } from '../preview/ViewerRenderer';
 import { renderPageControl } from '../preview/pageControl';
 import { addEditHint } from '../preview/editHint';
-import { resolveClickAction, openWithDefaultApp } from '../preview/clickAction';
+import {
+  resolveClickAction, resolveEditButtonAction, openWithDefaultApp,
+} from '../preview/clickAction';
+import { InteractiveViewerController } from '../preview/interactiveViewer';
 import { getDiagramPages, resolvePageFromSubpath, ensureMxfile, type DiagramPage } from '../model/xmlUtils';
 import { FileSource } from './FileSource';
 import { DRAWIO_FILE_EXT } from '../constants';
@@ -44,6 +47,7 @@ interface EmbedRegistry {
 class DrawioFileEmbed extends MarkdownRenderChild {
   private currentPage = 0;
   private pageResolvedFromSubpath = false;
+  private interactive: InteractiveViewerController | null = null;
 
   constructor(
     private plugin: DrawioPlugin,
@@ -78,8 +82,15 @@ class DrawioFileEmbed extends MarkdownRenderChild {
     }));
   }
 
+  onunload(): void {
+    this.interactive?.dispose();
+    this.interactive = null;
+  }
+
   private async render(): Promise<void> {
     const el = this.containerEl;
+    this.interactive?.dispose();
+    this.interactive = null;
     el.empty();
     el.addClass('drawio-embed');
     const action = resolveClickAction(this.plugin.settings.previewClickAction, 'file');
@@ -110,6 +121,7 @@ class DrawioFileEmbed extends MarkdownRenderChild {
           onPageChange: (page) => {
             this.currentPage = page;
             renderPreview(preview, xml, { ...this.plugin.previewOpts(), page });
+            this.interactive?.bindSvg(preview.querySelector('svg'), { preserveViewportHeight: true });
           },
           pin: !this.sourcePath ? undefined : {
             pinnedPage: resolvePageFromSubpath(pages, this.subpath),
@@ -120,6 +132,21 @@ class DrawioFileEmbed extends MarkdownRenderChild {
 
       if (Platform.isDesktopApp && action.hint) {
         addEditHint(el, action.hint.label, action.hint.icon);
+      }
+      if (Platform.isDesktopApp) {
+        this.interactive = new InteractiveViewerController(el, preview, {
+          isEnabled: () =>
+            resolveClickAction(this.plugin.settings.previewClickAction, 'file').kind === 'interactive',
+          onEdit: () => {
+            const editAction = resolveEditButtonAction(this.plugin.settings.editButtonAction, 'file');
+            if (editAction.kind === 'editor') {
+              this.plugin.openEditor(new FileSource(this.plugin.app, this.file));
+            } else if (editAction.kind === 'defaultApp') {
+              openWithDefaultApp(this.plugin.app, this.file.path);
+            }
+          },
+        });
+        this.interactive.bindSvg(preview.querySelector('svg'));
       }
     } catch (err) {
       el.createDiv({ cls: 'drawio-error', text: `Failed to render diagram: ${String(err)}` });
@@ -191,7 +218,7 @@ function registerEmbedPostProcessor(plugin: DrawioPlugin) {
           openWithDefaultApp(plugin.app, file.path);
         }
       });
-      void renderEmbedInto(plugin, span, file, subpath, ctx.sourcePath);
+      void renderEmbedInto(plugin, span, file, subpath, ctx);
     }
   });
 }
@@ -201,7 +228,7 @@ async function renderEmbedInto(
   span: HTMLElement,
   file: TFile,
   subpath: string | undefined,
-  sourcePath: string,
+  ctx: MarkdownPostProcessorContext,
 ) {
   span.empty();
   span.addClass('drawio-embed');
@@ -211,6 +238,7 @@ async function renderEmbedInto(
     const wrapped = ensureMxfile(xml);
     const pages = getDiagramPages(wrapped);
     const currentPage = resolvePageFromSubpath(pages, subpath);
+    let interactive: InteractiveViewerController | null = null;
 
     const preview = span.createDiv({ cls: 'drawio-preview' });
     renderPreview(preview, xml, { ...plugin.previewOpts(), page: currentPage });
@@ -222,12 +250,13 @@ async function renderEmbedInto(
         initialPage: currentPage,
         onPageChange: (page) => {
           renderPreview(preview, xml, { ...plugin.previewOpts(), page });
+          interactive?.bindSvg(preview.querySelector('svg'), { preserveViewportHeight: true });
         },
-        pin: !sourcePath ? undefined : {
+        pin: !ctx.sourcePath ? undefined : {
           pinnedPage: currentPage,
           onPin: (page) => {
             const name = pages[page]?.name;
-            if (name !== undefined) void pinEmbedPage(plugin.app, sourcePath, file, subpath, name);
+            if (name !== undefined) void pinEmbedPage(plugin.app, ctx.sourcePath, file, subpath, name);
           },
         },
       });
@@ -237,6 +266,22 @@ async function renderEmbedInto(
     span.toggleClass('drawio-no-action', Platform.isDesktopApp && action.kind === 'none');
     if (Platform.isDesktopApp && action.hint) {
       addEditHint(span, action.hint.label, action.hint.icon);
+    }
+    if (Platform.isDesktopApp) {
+      interactive = new InteractiveViewerController(span, preview, {
+        isEnabled: () =>
+          resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive',
+        onEdit: () => {
+          const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'file');
+          if (editAction.kind === 'editor') {
+            plugin.openEditor(new FileSource(plugin.app, file));
+          } else if (editAction.kind === 'defaultApp') {
+            openWithDefaultApp(plugin.app, file.path);
+          }
+        },
+      });
+      interactive.bindSvg(preview.querySelector('svg'));
+      ctx.addChild(interactive);
     }
   } catch (err) {
     span.empty();

--- a/src/file/EmbedRenderer.ts
+++ b/src/file/EmbedRenderer.ts
@@ -409,6 +409,7 @@ function applyStoredEmbedHeight(
   ctx: MarkdownPostProcessorContext | undefined,
   el: HTMLElement,
 ): void {
+  if (resolveClickAction(plugin.settings.previewClickAction, 'file').kind !== 'interactive') return;
   void readEmbedViewportHeight(
     plugin.app, sourcePath, file, subpath, ctx, el,
     getEmbedOccurrence(el), getLivePreviewSourceOffset(el),

--- a/src/file/EmbedRenderer.ts
+++ b/src/file/EmbedRenderer.ts
@@ -1,4 +1,5 @@
 import { MarkdownPostProcessorContext, MarkdownRenderChild, Notice, Platform, TFile } from 'obsidian';
+import { EditorView } from '@codemirror/view';
 import { renderPreview } from '../preview/ViewerRenderer';
 import { renderPageControl } from '../preview/pageControl';
 import { addEditHint } from '../preview/editHint';
@@ -6,6 +7,9 @@ import {
   resolveClickAction, resolveEditButtonAction, openWithDefaultApp,
 } from '../preview/clickAction';
 import { InteractiveViewerController } from '../preview/interactiveViewer';
+import {
+  readEmbedViewportHeight, writeEmbedViewportHeight,
+} from '../preview/embedViewportHeight';
 import { getDiagramPages, resolvePageFromSubpath, ensureMxfile, type DiagramPage } from '../model/xmlUtils';
 import { FileSource } from './FileSource';
 import { DRAWIO_FILE_EXT } from '../constants';
@@ -80,6 +84,15 @@ class DrawioFileEmbed extends MarkdownRenderChild {
     this.registerEvent(this.plugin.app.vault.on('modify', (f) => {
       if (f instanceof TFile && f.path === this.file.path) void this.render();
     }));
+    if (this.sourcePath) {
+      this.registerEvent(this.plugin.app.vault.on('modify', (f) => {
+        if (!(f instanceof TFile) || f.path !== this.sourcePath || !this.interactive) return;
+        applyStoredEmbedHeight(
+          this.plugin, this.interactive, this.sourcePath!, this.file, this.subpath,
+          undefined, this.containerEl,
+        );
+      }));
+    }
   }
 
   onunload(): void {
@@ -93,7 +106,19 @@ class DrawioFileEmbed extends MarkdownRenderChild {
     this.interactive = null;
     el.empty();
     el.addClass('drawio-embed');
+    if (this.sourcePath) markEmbedInsertion(el, this.sourcePath, this.file, this.subpath);
     const action = resolveClickAction(this.plugin.settings.previewClickAction, 'file');
+    let initialHeight: number | null = null;
+    if (Platform.isDesktopApp && action.kind === 'interactive' && this.sourcePath) {
+      try {
+        initialHeight = await readEmbedViewportHeight(
+          this.plugin.app, this.sourcePath, this.file, this.subpath,
+          undefined, undefined, getEmbedOccurrence(el), getLivePreviewSourceOffset(el),
+        );
+      } catch {
+        initialHeight = null;
+      }
+    }
     el.setAttribute('title', Platform.isDesktopApp ? action.title : 'Drawio diagram');
     el.toggleClass('drawio-no-action', Platform.isDesktopApp && action.kind === 'none');
     try {
@@ -137,6 +162,13 @@ class DrawioFileEmbed extends MarkdownRenderChild {
         this.interactive = new InteractiveViewerController(el, preview, {
           isEnabled: () =>
             resolveClickAction(this.plugin.settings.previewClickAction, 'file').kind === 'interactive',
+          initialHeight: initialHeight ?? undefined,
+          onHeightCommit: this.sourcePath ? (height) => {
+            commitEmbedHeight(
+              this.plugin, this.sourcePath!, this.file, this.subpath, height,
+              undefined, undefined, getEmbedOccurrence(el), getLivePreviewSourceOffset(el),
+            );
+          } : undefined,
           onEdit: () => {
             const editAction = resolveEditButtonAction(this.plugin.settings.editButtonAction, 'file');
             if (editAction.kind === 'editor') {
@@ -147,6 +179,10 @@ class DrawioFileEmbed extends MarkdownRenderChild {
           },
         });
         this.interactive.bindSvg(preview.querySelector('svg'));
+        scheduleStoredEmbedHeight(
+          this.plugin, this.interactive, this.sourcePath, this.file, this.subpath,
+          undefined, el,
+        );
       }
     } catch (err) {
       el.createDiv({ cls: 'drawio-error', text: `Failed to render diagram: ${String(err)}` });
@@ -232,6 +268,7 @@ async function renderEmbedInto(
 ) {
   span.empty();
   span.addClass('drawio-embed');
+  markEmbedInsertion(span, ctx.sourcePath, file, subpath);
   span.removeClasses(['file-embed', 'mod-generic', 'is-loaded']);
   try {
     const xml = await plugin.app.vault.read(file);
@@ -239,6 +276,18 @@ async function renderEmbedInto(
     const pages = getDiagramPages(wrapped);
     const currentPage = resolvePageFromSubpath(pages, subpath);
     let interactive: InteractiveViewerController | null = null;
+    let initialHeight: number | null = null;
+    if (Platform.isDesktopApp &&
+        resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive') {
+      try {
+        initialHeight = await readEmbedViewportHeight(
+          plugin.app, ctx.sourcePath, file, subpath, ctx, span,
+          getEmbedOccurrence(span), getLivePreviewSourceOffset(span),
+        );
+      } catch {
+        initialHeight = null;
+      }
+    }
 
     const preview = span.createDiv({ cls: 'drawio-preview' });
     renderPreview(preview, xml, { ...plugin.previewOpts(), page: currentPage });
@@ -271,6 +320,13 @@ async function renderEmbedInto(
       interactive = new InteractiveViewerController(span, preview, {
         isEnabled: () =>
           resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive',
+        initialHeight: initialHeight ?? undefined,
+        onHeightCommit: (height) => {
+          commitEmbedHeight(
+            plugin, ctx.sourcePath, file, subpath, height, ctx, span, getEmbedOccurrence(span),
+            getLivePreviewSourceOffset(span),
+          );
+        },
         onEdit: () => {
           const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'file');
           if (editAction.kind === 'editor') {
@@ -281,10 +337,117 @@ async function renderEmbedInto(
         },
       });
       interactive.bindSvg(preview.querySelector('svg'));
+      scheduleStoredEmbedHeight(
+        plugin, interactive, ctx.sourcePath, file, subpath, ctx, span,
+      );
+      interactive.registerEvent(plugin.app.vault.on('modify', (changed) => {
+        if (changed instanceof TFile && changed.path === ctx.sourcePath) {
+          applyStoredEmbedHeight(
+            plugin, interactive!, ctx.sourcePath, file, subpath, ctx, span,
+          );
+        }
+      }));
       ctx.addChild(interactive);
     }
   } catch (err) {
     span.empty();
     span.createDiv({ cls: 'drawio-error', text: `Failed to render diagram: ${String(err)}` });
+  }
+}
+
+function commitEmbedHeight(
+  plugin: DrawioPlugin,
+  sourcePath: string,
+  file: TFile,
+  subpath: string | undefined,
+  height: number,
+  ctx?: MarkdownPostProcessorContext,
+  el?: HTMLElement,
+  occurrence?: number,
+  sourceOffset?: number,
+): void {
+  void writeEmbedViewportHeight(
+    plugin.app, sourcePath, file, subpath, height, ctx, el, occurrence, sourceOffset,
+  ).then((outcome) => {
+    if (outcome === 'ambiguous') {
+      new Notice(
+        'Drawio: several identical embeds match this insertion. ' +
+        'Resize it in Reading view or give the links distinct page subpaths.',
+      );
+    } else if (outcome === 'no-match') {
+      new Notice('Drawio: could not locate this embed in the note; viewer height was not saved.');
+    }
+  }).catch((err) => {
+    new Notice(`Drawio: could not save viewer height — ${String(err)}`);
+  });
+}
+
+function scheduleStoredEmbedHeight(
+  plugin: DrawioPlugin,
+  interactive: InteractiveViewerController,
+  sourcePath: string | undefined,
+  file: TFile,
+  subpath: string | undefined,
+  ctx: MarkdownPostProcessorContext | undefined,
+  el: HTMLElement,
+): void {
+  if (!sourcePath) return;
+  const run = () => applyStoredEmbedHeight(
+    plugin, interactive, sourcePath, file, subpath, ctx, el,
+  );
+  const win = el.ownerDocument.defaultView;
+  if (win) win.requestAnimationFrame(run);
+  else run();
+}
+
+function applyStoredEmbedHeight(
+  plugin: DrawioPlugin,
+  interactive: InteractiveViewerController,
+  sourcePath: string,
+  file: TFile,
+  subpath: string | undefined,
+  ctx: MarkdownPostProcessorContext | undefined,
+  el: HTMLElement,
+): void {
+  void readEmbedViewportHeight(
+    plugin.app, sourcePath, file, subpath, ctx, el,
+    getEmbedOccurrence(el), getLivePreviewSourceOffset(el),
+  ).then((height) => {
+    if (height !== null) interactive.applyPersistedHeight(height);
+  }).catch(() => { /* Keep the already rendered automatic height. */ });
+}
+
+function markEmbedInsertion(
+  el: HTMLElement,
+  sourcePath: string,
+  file: TFile,
+  subpath: string | undefined,
+): void {
+  el.dataset.drawioInsertionKey = JSON.stringify([
+    sourcePath,
+    file.path,
+    subpath?.replace(/^#/, '') ?? '',
+  ]);
+}
+
+function getEmbedOccurrence(el: HTMLElement): number {
+  const key = el.dataset.drawioInsertionKey;
+  if (!key) return 0;
+  const scope = el.closest<HTMLElement>(
+    '.markdown-preview-view, .markdown-source-view, .workspace-leaf-content',
+  ) ?? el.parentElement;
+  if (!scope) return 0;
+  const peers = Array.from(scope.querySelectorAll<HTMLElement>('.drawio-embed'))
+    .filter((candidate) => candidate.dataset.drawioInsertionKey === key);
+  const index = peers.indexOf(el);
+  return index === -1 ? 0 : index;
+}
+
+function getLivePreviewSourceOffset(el: HTMLElement): number | undefined {
+  try {
+    const view = EditorView.findFromDOM(el);
+    return view?.posAtDOM(el, 0);
+  } catch {
+    return undefined;
   }
 }

--- a/src/preview/DrawioPreviewFileView.ts
+++ b/src/preview/DrawioPreviewFileView.ts
@@ -3,7 +3,8 @@ import { DRAWIO_VIEW_TYPE } from '../constants';
 import { renderPreview } from './ViewerRenderer';
 import { renderPageControl } from './pageControl';
 import { addEditHint } from './editHint';
-import { resolveClickAction, openWithDefaultApp } from './clickAction';
+import { resolveClickAction, resolveEditButtonAction, openWithDefaultApp } from './clickAction';
+import { InteractiveViewerController } from './interactiveViewer';
 import { getDiagramPages, ensureMxfile } from '../model/xmlUtils';
 import { FileSource } from '../file/FileSource';
 import type DrawioPlugin from '../main';
@@ -16,6 +17,8 @@ import type DrawioPlugin from '../main';
  * follows the "Preview click action" setting.
  */
 export class DrawioPreviewFileView extends TextFileView {
+  private interactive: InteractiveViewerController | null = null;
+
   constructor(leaf: WorkspaceLeaf, private plugin: DrawioPlugin) {
     super(leaf);
     this.data = '';
@@ -33,12 +36,16 @@ export class DrawioPreviewFileView extends TextFileView {
   }
 
   clear(): void {
+    this.interactive?.dispose();
+    this.interactive = null;
     this.data = '';
     this.contentEl.empty();
   }
 
   private render(): void {
     const c = this.contentEl;
+    this.interactive?.dispose();
+    this.interactive = null;
     c.empty();
     c.addClass('drawio-preview-file-view');
 
@@ -69,12 +76,29 @@ export class DrawioPreviewFileView extends TextFileView {
         initialPage: 0,
         onPageChange: (page) => {
           renderPreview(preview, this.data, { ...this.plugin.previewOpts(), page });
+          this.interactive?.bindSvg(preview.querySelector('svg'), { preserveViewportHeight: true });
         },
       });
     }
 
     if (Platform.isDesktopApp && action.hint) {
       addEditHint(previewWrap, action.hint.label, action.hint.icon);
+    }
+    if (Platform.isDesktopApp) {
+      this.interactive = new InteractiveViewerController(c, preview, {
+        isEnabled: () =>
+          resolveClickAction(this.plugin.settings.previewClickAction, 'file').kind === 'interactive',
+        onEdit: () => {
+          if (!this.file) return;
+          const editAction = resolveEditButtonAction(this.plugin.settings.editButtonAction, 'file');
+          if (editAction.kind === 'editor') {
+            this.plugin.openEditor(new FileSource(this.plugin.app, this.file));
+          } else if (editAction.kind === 'defaultApp') {
+            openWithDefaultApp(this.plugin.app, this.file.path);
+          }
+        },
+      });
+      this.interactive.bindSvg(preview.querySelector('svg'));
     }
   }
 

--- a/src/preview/clickAction.ts
+++ b/src/preview/clickAction.ts
@@ -1,10 +1,10 @@
 import { App, Notice } from 'obsidian';
-import type { PreviewClickAction } from '../settings';
+import type { EditButtonAction, PreviewClickAction } from '../settings';
 
 export type PreviewSurface = 'codeblock' | 'file';
 
 export interface ResolvedClickAction {
-  kind: 'editor' | 'defaultApp' | 'none';
+  kind: 'editor' | 'defaultApp' | 'interactive' | 'none';
   /** Hover-hint label and icon; absent when kind is 'none' (no hint shown). */
   hint?: { label: string; icon: string };
   /** Tooltip for the preview container. */
@@ -21,6 +21,13 @@ export function resolveClickAction(
   surface: PreviewSurface,
 ): ResolvedClickAction {
   if (action === 'none') return { kind: 'none', title: 'Drawio diagram' };
+  if (action === 'interactive') {
+    return {
+      kind: 'interactive',
+      hint: { label: 'Explore', icon: 'move' },
+      title: 'Click to explore diagram',
+    };
+  }
   if (action === 'defaultApp' && surface === 'file') {
     return {
       kind: 'defaultApp',
@@ -29,6 +36,14 @@ export function resolveClickAction(
     };
   }
   return { kind: 'editor', hint: { label: 'Edit', icon: 'pencil' }, title: 'Click to edit diagram' };
+}
+
+/** Resolve the explicit Edit button separately from preview activation. */
+export function resolveEditButtonAction(
+  action: EditButtonAction,
+  surface: PreviewSurface,
+): ResolvedClickAction {
+  return resolveClickAction(action, surface);
 }
 
 /**

--- a/src/preview/embedViewportHeight.ts
+++ b/src/preview/embedViewportHeight.ts
@@ -1,0 +1,155 @@
+import { App, MarkdownPostProcessorContext, parseLinktext, TFile } from 'obsidian';
+import { parseViewportHeightComment, upsertViewportHeightComment } from './viewportHeight';
+
+export type EmbedHeightWriteOutcome = 'written' | 'no-match' | 'ambiguous';
+
+interface EmbedCacheItem {
+  link: string;
+  original: string;
+  position: { start: { offset: number }; end: { offset: number } };
+}
+
+interface LocatedEmbed {
+  item: EmbedCacheItem;
+  allItems: EmbedCacheItem[];
+}
+
+export async function readEmbedViewportHeight(
+  app: App,
+  sourcePath: string,
+  targetFile: TFile,
+  subpath?: string,
+  ctx?: MarkdownPostProcessorContext,
+  el?: HTMLElement,
+  occurrence?: number,
+  sourceOffset?: number,
+): Promise<number | null> {
+  const note = app.vault.getAbstractFileByPath(sourcePath);
+  if (!(note instanceof TFile)) return null;
+  const doc = await app.vault.cachedRead(note);
+  const located = locateEmbed(
+    app, sourcePath, targetFile, subpath, doc, ctx, el, occurrence, sourceOffset,
+  );
+  if (located.outcome !== 'found') return null;
+  const offset = resolveCurrentOffset(doc, located.value);
+  if (offset === null) return null;
+  const line = lineAtOffset(doc, offset);
+  return parseViewportHeightComment(doc.split('\n')[line - 1]);
+}
+
+export async function writeEmbedViewportHeight(
+  app: App,
+  sourcePath: string,
+  targetFile: TFile,
+  subpath: string | undefined,
+  height: number,
+  ctx?: MarkdownPostProcessorContext,
+  el?: HTMLElement,
+  occurrence?: number,
+  sourceOffset?: number,
+): Promise<EmbedHeightWriteOutcome> {
+  const note = app.vault.getAbstractFileByPath(sourcePath);
+  if (!(note instanceof TFile)) return 'no-match';
+  const snapshot = await app.vault.cachedRead(note);
+  const located = locateEmbed(
+    app, sourcePath, targetFile, subpath, snapshot, ctx, el, occurrence, sourceOffset,
+  );
+  if (located.outcome !== 'found') return located.outcome;
+  let written = false;
+  await app.vault.process(note, (doc) => {
+    const offset = resolveCurrentOffset(doc, located.value);
+    if (offset === null) return doc;
+    written = true;
+    return upsertViewportHeightComment(doc, lineAtOffset(doc, offset), height);
+  });
+  return written ? 'written' : 'no-match';
+}
+
+function locateEmbed(
+  app: App,
+  sourcePath: string,
+  targetFile: TFile,
+  subpath: string | undefined,
+  doc: string,
+  ctx?: MarkdownPostProcessorContext,
+  el?: HTMLElement,
+  occurrence?: number,
+  sourceOffset?: number,
+): { outcome: 'found'; value: LocatedEmbed } | { outcome: 'no-match' | 'ambiguous' } {
+  const embeds = (app.metadataCache.getCache(sourcePath)?.embeds ?? []) as EmbedCacheItem[];
+  const expectedSubpath = normalizeSubpath(subpath);
+  const candidates = embeds.filter((item) => {
+    const parsed = parseLinktext(sourceLinktext(item));
+    const dest = app.metadataCache.getFirstLinkpathDest(parsed.path, sourcePath);
+    return dest?.path === targetFile.path && normalizeSubpath(parsed.subpath) === expectedSubpath;
+  });
+  if (candidates.length === 0) return { outcome: 'no-match' };
+
+  if (sourceOffset !== undefined) {
+    const atPosition = candidates.filter((item) =>
+      sourceOffset >= item.position.start.offset && sourceOffset <= item.position.end.offset);
+    if (atPosition.length === 1) {
+      return { outcome: 'found', value: { item: atPosition[0]!, allItems: embeds } };
+    }
+  }
+
+  const info = ctx && el ? ctx.getSectionInfo(el) : null;
+  if (info) {
+    const inSection = candidates.filter((item) => {
+      const offset = resolveCurrentOffset(doc, { item, allItems: embeds });
+      if (offset === null) return false;
+      const line = lineAtOffset(doc, offset);
+      return line >= info.lineStart && line <= info.lineEnd;
+    });
+    if (inSection.length === 1) {
+      return { outcome: 'found', value: { item: inSection[0]!, allItems: embeds } };
+    }
+  }
+
+  if (occurrence !== undefined && candidates[occurrence]) {
+    return { outcome: 'found', value: { item: candidates[occurrence]!, allItems: embeds } };
+  }
+
+  return candidates.length === 1
+    ? { outcome: 'found', value: { item: candidates[0]!, allItems: embeds } }
+    : { outcome: 'ambiguous' };
+}
+
+function sourceLinktext(item: EmbedCacheItem): string {
+  const match = /^!\[\[([\s\S]*?)\]\]$/.exec(item.original.trim());
+  if (!match) return item.link;
+  return match[1]!.split('|', 1)[0]!.trim();
+}
+
+function resolveCurrentOffset(doc: string, located: LocatedEmbed): number | null {
+  const { item, allItems } = located;
+  const start = item.position.start.offset;
+  if (doc.slice(start, start + item.original.length) === item.original) return start;
+
+  const peers = allItems.filter((candidate) => candidate.original === item.original);
+  const ordinal = peers.indexOf(item);
+  const occurrences: number[] = [];
+  let from = 0;
+  while (from <= doc.length) {
+    const found = doc.indexOf(item.original, from);
+    if (found === -1) break;
+    occurrences.push(found);
+    from = found + item.original.length;
+  }
+  return ordinal >= 0 && occurrences.length === peers.length
+    ? occurrences[ordinal] ?? null
+    : occurrences.length === 1 ? occurrences[0]! : null;
+}
+
+function normalizeSubpath(subpath: string | undefined | null): string {
+  if (!subpath) return '';
+  return subpath.startsWith('#') ? subpath : `#${subpath}`;
+}
+
+function lineAtOffset(doc: string, offset: number): number {
+  let line = 0;
+  for (let index = 0; index < offset; index += 1) {
+    if (doc.charCodeAt(index) === 10) line += 1;
+  }
+  return line;
+}

--- a/src/preview/interactiveViewer.ts
+++ b/src/preview/interactiveViewer.ts
@@ -1,0 +1,409 @@
+import { MarkdownRenderChild } from 'obsidian';
+import { MAX_VIEWPORT_HEIGHT, MIN_VIEWPORT_HEIGHT } from './viewportHeight';
+
+export interface InteractiveViewerOptions {
+  /** Resolved at interaction time so settings changes affect existing previews. */
+  isEnabled?: () => boolean;
+  initialHeight?: number;
+  onHeightCommit?: (height: number) => void;
+}
+
+export interface BindSvgOptions {
+  /** Page changes replace the SVG but must not resize the surrounding insertion. */
+  preserveViewportHeight?: boolean;
+}
+
+interface ViewBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const ZOOM_STEP = 1.2;
+const MAX_SCALE = 8;
+const SCALE_EPSILON = 0.0001;
+
+/**
+ * Minimal interactive-viewer lifecycle and activation shell.
+ *
+ * Zoom, pan, Edit, and fullscreen are intentionally added by later stages. This
+ * walking skeleton only owns activation, exit, a placeholder toolbar, and cleanup.
+ */
+export class InteractiveViewerController extends MarkdownRenderChild {
+  private active = false;
+  private disposed = false;
+  private svg: SVGSVGElement | null = null;
+  private baseBox: ViewBox | null = null;
+  private currentBox: ViewBox | null = null;
+  private frame: number | null = null;
+  private toolbar: HTMLElement;
+  private zoomInButton!: HTMLButtonElement;
+  private zoomOutButton!: HTMLButtonElement;
+  private fitButton!: HTMLButtonElement;
+  private editButton!: HTMLButtonElement;
+  private resizeHandle: HTMLElement;
+  private doc: Document;
+  private viewportInitialized = false;
+  private manuallyResized = false;
+  private resizeStartY = 0;
+  private resizeStartHeight = 0;
+  private viewportHeight = 0;
+  private panStartX = 0;
+  private panStartY = 0;
+  private panStartBox: ViewBox | null = null;
+
+  constructor(
+    private root: HTMLElement,
+    private preview: HTMLElement,
+    private opts: InteractiveViewerOptions = {},
+  ) {
+    super(root);
+    this.doc = root.ownerDocument;
+    this.root.classList.add('drawio-interactive');
+    this.toolbar = this.createToolbar();
+    this.resizeHandle = this.createResizeHandle();
+    this.root.addEventListener('click', this.onRootClick);
+    this.preview.addEventListener('wheel', this.onWheel, { passive: false });
+    this.preview.addEventListener('pointerdown', this.onPanStart);
+    this.doc.addEventListener('click', this.onDocumentClick);
+    this.doc.addEventListener('keydown', this.onDocumentKeydown);
+    this.doc.defaultView?.addEventListener('resize', this.onWindowResize);
+  }
+
+  get isActive(): boolean { return this.active; }
+
+  bindSvg(svg: SVGSVGElement | null, opts: BindSvgOptions = {}): void {
+    const preservedHeight = opts.preserveViewportHeight && this.viewportInitialized
+      ? this.viewportHeight
+      : null;
+    const wasManuallyResized = this.manuallyResized;
+    this.cancelFrame();
+    this.svg?.classList.remove('drawio-interactive-svg');
+    this.svg = svg;
+    this.baseBox = svg ? parseViewBox(svg.getAttribute('viewBox')) : null;
+    this.currentBox = this.baseBox ? { ...this.baseBox } : null;
+    this.viewportInitialized = false;
+    this.manuallyResized = preservedHeight === null
+      ? this.opts.initialHeight !== undefined
+      : wasManuallyResized;
+    this.deactivate();
+    this.updateControls();
+    if (this.opts.isEnabled?.() === false) return;
+    if (preservedHeight !== null && svg && this.baseBox) {
+      this.preview.classList.add('drawio-interactive-viewport');
+      svg.classList.add('drawio-interactive-svg');
+      this.setViewportHeight(preservedHeight);
+      this.viewportInitialized = true;
+      return;
+    }
+    this.initializeViewport();
+  }
+
+  activate(): void {
+    if (this.disposed || this.opts.isEnabled?.() === false || !this.svg) return;
+    this.initializeViewport();
+    this.active = true;
+    this.root.classList.add('drawio-interactive-active');
+    this.updateControls();
+  }
+
+  deactivate(): void {
+    this.endPan();
+    this.active = false;
+    this.root.classList.remove('drawio-interactive-active');
+    this.updateControls();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.deactivate();
+    this.root.classList.remove('drawio-interactive');
+    this.root.removeEventListener('click', this.onRootClick);
+    this.preview.removeEventListener('wheel', this.onWheel);
+    this.preview.removeEventListener('pointerdown', this.onPanStart);
+    this.doc.removeEventListener('click', this.onDocumentClick);
+    this.doc.removeEventListener('keydown', this.onDocumentKeydown);
+    this.doc.removeEventListener('pointermove', this.onResizeMove);
+    this.doc.removeEventListener('pointerup', this.onResizeEnd);
+    this.doc.removeEventListener('pointermove', this.onPanMove);
+    this.doc.removeEventListener('pointerup', this.onPanEnd);
+    this.doc.defaultView?.removeEventListener('resize', this.onWindowResize);
+    this.cancelFrame();
+    this.toolbar.remove();
+    this.resizeHandle.remove();
+    this.preview.classList.remove('drawio-interactive-viewport');
+    this.preview.style.removeProperty('height');
+    this.svg?.classList.remove('drawio-interactive-svg');
+    this.svg = null;
+    this.baseBox = null;
+    this.currentBox = null;
+  }
+
+  onunload(): void {
+    this.dispose();
+  }
+
+  private createToolbar(): HTMLElement {
+    const toolbar = this.root.createDiv({ cls: 'drawio-interactive-toolbar' });
+    toolbar.setAttribute('aria-label', 'Interactive viewer controls');
+    this.zoomInButton = this.createButton(toolbar, '+', 'Zoom in', () => this.zoomBy(ZOOM_STEP));
+    this.zoomOutButton = this.createButton(toolbar, '−', 'Zoom out', () => this.zoomBy(1 / ZOOM_STEP));
+    this.fitButton = this.createButton(toolbar, 'Fit', 'Fit diagram', () => this.fit());
+    this.editButton = this.createButton(toolbar, 'Edit', 'Edit diagram', () => {});
+    return toolbar;
+  }
+
+  private createResizeHandle(): HTMLElement {
+    const handle = this.root.createDiv({ cls: 'drawio-interactive-resize-handle' });
+    handle.setAttribute('role', 'separator');
+    handle.setAttribute('aria-label', 'Resize interactive viewer');
+    handle.setAttribute('aria-orientation', 'horizontal');
+    handle.addEventListener('pointerdown', this.onResizeStart);
+    return handle;
+  }
+
+  private createButton(
+    toolbar: HTMLElement,
+    label: string,
+    ariaLabel: string,
+    action: () => void,
+  ): HTMLButtonElement {
+    const button = toolbar.createEl('button', { text: label });
+    button.disabled = true;
+    button.setAttribute('aria-label', ariaLabel);
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      action();
+    });
+    return button;
+  }
+
+  private onRootClick = (event: MouseEvent): void => {
+    const target = this.eventNode(event);
+    if (target && this.preview.contains(target)) this.activate();
+  };
+
+  private onDocumentClick = (event: MouseEvent): void => {
+    if (!this.active) return;
+    const target = this.eventNode(event);
+    if (!target || !this.root.contains(target)) this.deactivate();
+  };
+
+  private onDocumentKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') this.deactivate();
+  };
+
+  private onWheel = (event: WheelEvent): void => {
+    if (!this.active || event.deltaY === 0) return;
+    event.preventDefault();
+    this.zoomBy(event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP, event.clientX, event.clientY);
+  };
+
+  private onPanStart = (event: PointerEvent): void => {
+    if (!this.active) this.activate();
+    const base = this.baseBox;
+    const current = this.currentBox;
+    if (!this.active || event.button !== 0 || !base || !current) return;
+    if (base.width / current.width <= 1 + SCALE_EPSILON) return;
+    event.preventDefault();
+    event.stopPropagation();
+    this.panStartX = event.clientX;
+    this.panStartY = event.clientY;
+    this.panStartBox = { ...current };
+    this.root.classList.add('drawio-interactive-panning');
+    this.doc.addEventListener('pointermove', this.onPanMove);
+    this.doc.addEventListener('pointerup', this.onPanEnd);
+    this.doc.addEventListener('pointercancel', this.onPanEnd);
+  };
+
+  private onPanMove = (event: PointerEvent): void => {
+    const svg = this.svg;
+    const base = this.baseBox;
+    const start = this.panStartBox;
+    if (!svg || !base || !start) return;
+    const rect = svg.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    event.preventDefault();
+    this.currentBox = {
+      x: clamp(
+        start.x - (event.clientX - this.panStartX) * start.width / rect.width,
+        base.x,
+        base.x + base.width - start.width,
+      ),
+      y: clamp(
+        start.y - (event.clientY - this.panStartY) * start.height / rect.height,
+        base.y,
+        base.y + base.height - start.height,
+      ),
+      width: start.width,
+      height: start.height,
+    };
+    this.scheduleViewBoxWrite();
+  };
+
+  private onPanEnd = (): void => {
+    this.endPan();
+  };
+
+  private endPan(): void {
+    if (!this.panStartBox) return;
+    this.panStartBox = null;
+    this.root.classList.remove('drawio-interactive-panning');
+    this.doc.removeEventListener('pointermove', this.onPanMove);
+    this.doc.removeEventListener('pointerup', this.onPanEnd);
+    this.doc.removeEventListener('pointercancel', this.onPanEnd);
+  }
+
+  private onResizeStart = (event: PointerEvent): void => {
+    if (!this.active) return;
+    event.preventDefault();
+    event.stopPropagation();
+    this.resizeStartY = event.clientY;
+    this.resizeStartHeight = parseFloat(this.preview.style.height)
+      || this.preview.getBoundingClientRect().height;
+    this.manuallyResized = true;
+    this.root.classList.add('drawio-interactive-resizing');
+    this.doc.addEventListener('pointermove', this.onResizeMove);
+    this.doc.addEventListener('pointerup', this.onResizeEnd);
+  };
+
+  private onResizeMove = (event: PointerEvent): void => {
+    const height = clamp(
+      this.resizeStartHeight + event.clientY - this.resizeStartY,
+      MIN_VIEWPORT_HEIGHT,
+      MAX_VIEWPORT_HEIGHT,
+    );
+    this.setViewportHeight(height);
+    this.fit();
+  };
+
+  private onResizeEnd = (): void => {
+    this.root.classList.remove('drawio-interactive-resizing');
+    this.doc.removeEventListener('pointermove', this.onResizeMove);
+    this.doc.removeEventListener('pointerup', this.onResizeEnd);
+    this.opts.onHeightCommit?.(Math.round(this.viewportHeight));
+  };
+
+  private onWindowResize = (): void => {
+    if (this.viewportInitialized && !this.manuallyResized) this.initializeViewport(true);
+  };
+
+  private initializeViewport(force = false): void {
+    if (this.viewportInitialized && !force) return;
+    const base = this.baseBox;
+    const svg = this.svg;
+    const win = this.doc.defaultView;
+    if (!base || !svg || !win) return;
+    const width = this.preview.getBoundingClientRect().width
+      || this.root.getBoundingClientRect().width
+      || base.width;
+    const proportionalHeight = width * base.height / base.width;
+    const availableHeight = Math.max(1, win.innerHeight);
+    this.preview.classList.add('drawio-interactive-viewport');
+    svg.classList.add('drawio-interactive-svg');
+    const height = this.opts.initialHeight === undefined
+      ? Math.min(proportionalHeight, availableHeight)
+      : clamp(this.opts.initialHeight, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
+    this.setViewportHeight(height);
+    this.viewportInitialized = true;
+  }
+
+  private setViewportHeight(height: number): void {
+    this.viewportHeight = height;
+    this.preview.style.height = `${height}px`;
+    this.resizeHandle.style.top = `${Math.max(0, height - 5)}px`;
+  }
+
+  private zoomBy(factor: number, clientX?: number, clientY?: number): void {
+    const svg = this.svg;
+    const base = this.baseBox;
+    const current = this.currentBox;
+    if (!svg || !base || !current) return;
+
+    const scale = base.width / current.width;
+    const nextScale = clamp(scale * factor, 1, MAX_SCALE);
+    if (Math.abs(nextScale - scale) < SCALE_EPSILON) return;
+
+    const rect = svg.getBoundingClientRect();
+    const rx = clientX === undefined || rect.width <= 0
+      ? 0.5
+      : clamp((clientX - rect.left) / rect.width, 0, 1);
+    const ry = clientY === undefined || rect.height <= 0
+      ? 0.5
+      : clamp((clientY - rect.top) / rect.height, 0, 1);
+    const anchorX = current.x + rx * current.width;
+    const anchorY = current.y + ry * current.height;
+    const width = base.width / nextScale;
+    const height = base.height / nextScale;
+
+    this.currentBox = {
+      x: clamp(anchorX - rx * width, base.x, base.x + base.width - width),
+      y: clamp(anchorY - ry * height, base.y, base.y + base.height - height),
+      width,
+      height,
+    };
+    this.updateControls();
+    this.scheduleViewBoxWrite();
+  }
+
+  private fit(): void {
+    if (!this.baseBox) return;
+    this.currentBox = { ...this.baseBox };
+    this.updateControls();
+    this.scheduleViewBoxWrite();
+  }
+
+  private updateControls(): void {
+    if (!this.zoomInButton) return;
+    const ready = this.active && this.baseBox !== null && this.currentBox !== null;
+    const scale = ready ? this.baseBox!.width / this.currentBox!.width : 1;
+    this.root.classList.toggle('drawio-interactive-zoomed', ready && scale > 1 + SCALE_EPSILON);
+    this.zoomInButton.disabled = !ready || scale >= MAX_SCALE - SCALE_EPSILON;
+    this.zoomOutButton.disabled = !ready || scale <= 1 + SCALE_EPSILON;
+    this.fitButton.disabled = !ready || scale <= 1 + SCALE_EPSILON;
+    // Wired in the toolbar/Edit stage.
+    this.editButton.disabled = true;
+  }
+
+  private scheduleViewBoxWrite(): void {
+    const win = this.doc.defaultView;
+    if (!win || this.frame !== null) return;
+    this.frame = win.requestAnimationFrame(() => {
+      this.frame = null;
+      if (this.svg && this.currentBox) {
+        const { x, y, width, height } = this.currentBox;
+        this.svg.setAttribute('viewBox', `${x} ${y} ${width} ${height}`);
+      }
+    });
+  }
+
+  private cancelFrame(): void {
+    if (this.frame === null) return;
+    this.doc.defaultView?.cancelAnimationFrame(this.frame);
+    this.frame = null;
+  }
+
+  /** Use the preview document's DOM realm so popout-window events are accepted. */
+  private eventNode(event: Event): Node | null {
+    const NodeCtor = this.doc.defaultView?.Node;
+    return NodeCtor && event.target instanceof NodeCtor ? event.target : null;
+  }
+}
+
+function parseViewBox(raw: string | null): ViewBox | null {
+  if (!raw) return null;
+  const values = raw.trim().split(/[\s,]+/).map(Number);
+  if (values.length !== 4 || values.some((value) => !Number.isFinite(value))) return null;
+  const x = values[0]!;
+  const y = values[1]!;
+  const width = values[2]!;
+  const height = values[3]!;
+  return width > 0 && height > 0 ? { x, y, width, height } : null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/src/preview/interactiveViewer.ts
+++ b/src/preview/interactiveViewer.ts
@@ -6,6 +6,7 @@ export interface InteractiveViewerOptions {
   isEnabled?: () => boolean;
   initialHeight?: number;
   onHeightCommit?: (height: number) => void;
+  onEdit?: () => void;
 }
 
 export interface BindSvgOptions {
@@ -41,7 +42,9 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   private zoomInButton!: HTMLButtonElement;
   private zoomOutButton!: HTMLButtonElement;
   private fitButton!: HTMLButtonElement;
+  private fullscreenButton!: HTMLButtonElement;
   private editButton!: HTMLButtonElement;
+  private closeFullscreenButton!: HTMLButtonElement;
   private resizeHandle: HTMLElement;
   private doc: Document;
   private viewportInitialized = false;
@@ -68,6 +71,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.preview.addEventListener('pointerdown', this.onPanStart);
     this.doc.addEventListener('click', this.onDocumentClick);
     this.doc.addEventListener('keydown', this.onDocumentKeydown);
+    this.doc.addEventListener('fullscreenchange', this.onFullscreenChange);
     this.doc.defaultView?.addEventListener('resize', this.onWindowResize);
   }
 
@@ -105,6 +109,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.initializeViewport();
     this.active = true;
     this.root.classList.add('drawio-interactive-active');
+    this.setHintHidden(true);
     this.updateControls();
   }
 
@@ -112,6 +117,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.endPan();
     this.active = false;
     this.root.classList.remove('drawio-interactive-active');
+    this.setHintHidden(false);
     this.updateControls();
   }
 
@@ -120,11 +126,13 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.disposed = true;
     this.deactivate();
     this.root.classList.remove('drawio-interactive');
+    this.root.classList.remove('drawio-interactive-fullscreen');
     this.root.removeEventListener('click', this.onRootClick);
     this.preview.removeEventListener('wheel', this.onWheel);
     this.preview.removeEventListener('pointerdown', this.onPanStart);
     this.doc.removeEventListener('click', this.onDocumentClick);
     this.doc.removeEventListener('keydown', this.onDocumentKeydown);
+    this.doc.removeEventListener('fullscreenchange', this.onFullscreenChange);
     this.doc.removeEventListener('pointermove', this.onResizeMove);
     this.doc.removeEventListener('pointerup', this.onResizeEnd);
     this.doc.removeEventListener('pointermove', this.onPanMove);
@@ -151,7 +159,14 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.zoomInButton = this.createButton(toolbar, '+', 'Zoom in', () => this.zoomBy(ZOOM_STEP));
     this.zoomOutButton = this.createButton(toolbar, '−', 'Zoom out', () => this.zoomBy(1 / ZOOM_STEP));
     this.fitButton = this.createButton(toolbar, 'Fit', 'Fit diagram', () => this.fit());
-    this.editButton = this.createButton(toolbar, 'Edit', 'Edit diagram', () => {});
+    this.editButton = this.createButton(toolbar, 'Edit', 'Edit diagram', () => this.opts.onEdit?.());
+    this.fullscreenButton = this.createButton(
+      toolbar, 'Full screen', 'Enter full screen', () => { void this.enterFullscreen(); },
+    );
+    this.closeFullscreenButton = this.createButton(
+      toolbar, '×', 'Exit full screen', () => { void this.exitFullscreen(); },
+    );
+    this.closeFullscreenButton.hidden = true;
     return toolbar;
   }
 
@@ -193,8 +208,24 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   };
 
   private onDocumentKeydown = (event: KeyboardEvent): void => {
-    if (event.key === 'Escape') this.deactivate();
+    if (event.key !== 'Escape') return;
+    if (this.doc.fullscreenElement === this.root) void this.exitFullscreen();
+    this.deactivate();
   };
+
+  private onFullscreenChange = (): void => {
+    const fullscreen = this.doc.fullscreenElement === this.root;
+    this.root.classList.toggle('drawio-interactive-fullscreen', fullscreen);
+    this.fullscreenButton.hidden = fullscreen;
+    this.closeFullscreenButton.hidden = !fullscreen;
+    this.closeFullscreenButton.disabled = !fullscreen;
+  };
+
+  private setHintHidden(hidden: boolean): void {
+    for (const hint of Array.from(this.root.querySelectorAll<HTMLElement>('.drawio-edit-hint'))) {
+      hint.hidden = hidden;
+    }
+  }
 
   private onWheel = (event: WheelEvent): void => {
     if (!this.active || event.deltaY === 0) return;
@@ -255,6 +286,26 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.doc.removeEventListener('pointermove', this.onPanMove);
     this.doc.removeEventListener('pointerup', this.onPanEnd);
     this.doc.removeEventListener('pointercancel', this.onPanEnd);
+  }
+
+  private async enterFullscreen(): Promise<void> {
+    if (!this.active || typeof this.root.requestFullscreen !== 'function') return;
+    try {
+      await this.root.requestFullscreen();
+      this.onFullscreenChange();
+    } catch {
+      // The host may deny fullscreen; the rest of the viewer remains usable.
+    }
+  }
+
+  private async exitFullscreen(): Promise<void> {
+    if (this.doc.fullscreenElement !== this.root || typeof this.doc.exitFullscreen !== 'function') return;
+    try {
+      await this.doc.exitFullscreen();
+      this.onFullscreenChange();
+    } catch {
+      // The host may already be leaving fullscreen; fullscreenchange reconciles state.
+    }
   }
 
   private onResizeStart = (event: PointerEvent): void => {
@@ -364,8 +415,8 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.zoomInButton.disabled = !ready || scale >= MAX_SCALE - SCALE_EPSILON;
     this.zoomOutButton.disabled = !ready || scale <= 1 + SCALE_EPSILON;
     this.fitButton.disabled = !ready || scale <= 1 + SCALE_EPSILON;
-    // Wired in the toolbar/Edit stage.
-    this.editButton.disabled = true;
+    this.fullscreenButton.disabled = !ready || typeof this.root.requestFullscreen !== 'function';
+    this.editButton.disabled = !ready || this.opts.onEdit === undefined;
   }
 
   private scheduleViewBoxWrite(): void {

--- a/src/preview/interactiveViewer.ts
+++ b/src/preview/interactiveViewer.ts
@@ -78,10 +78,11 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   get isActive(): boolean { return this.active; }
 
   applyPersistedHeight(height: number): void {
-    if (this.disposed) return;
+    if (this.disposed || this.opts.isEnabled?.() === false) return;
     const next = clamp(height, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
     this.opts.initialHeight = next;
     this.manuallyResized = true;
+    if (this.viewportInitialized && Math.abs(this.viewportHeight - next) < 0.5) return;
     if (!this.svg || !this.baseBox) return;
     this.preview.classList.add('drawio-interactive-viewport');
     this.svg.classList.add('drawio-interactive-svg');
@@ -148,6 +149,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.doc.removeEventListener('fullscreenchange', this.onFullscreenChange);
     this.doc.removeEventListener('pointermove', this.onResizeMove);
     this.doc.removeEventListener('pointerup', this.onResizeEnd);
+    this.doc.removeEventListener('pointercancel', this.onResizeEnd);
     this.doc.removeEventListener('pointermove', this.onPanMove);
     this.doc.removeEventListener('pointerup', this.onPanEnd);
     this.doc.defaultView?.removeEventListener('resize', this.onWindowResize);
@@ -172,7 +174,9 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.zoomInButton = this.createButton(toolbar, '+', 'Zoom in', () => this.zoomBy(ZOOM_STEP));
     this.zoomOutButton = this.createButton(toolbar, '−', 'Zoom out', () => this.zoomBy(1 / ZOOM_STEP));
     this.fitButton = this.createButton(toolbar, 'Fit', 'Fit diagram', () => this.fit());
-    this.editButton = this.createButton(toolbar, 'Edit', 'Edit diagram', () => this.opts.onEdit?.());
+    this.editButton = this.createButton(
+      toolbar, 'Edit', 'Edit diagram', () => { void this.runEditAction(); },
+    );
     this.fullscreenButton = this.createButton(
       toolbar, 'Full screen', 'Enter full screen', () => { void this.enterFullscreen(); },
     );
@@ -321,6 +325,12 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     }
   }
 
+  private async runEditAction(): Promise<void> {
+    if (this.doc.fullscreenElement === this.root) await this.exitFullscreen();
+    this.deactivate();
+    this.opts.onEdit?.();
+  }
+
   private onResizeStart = (event: PointerEvent): void => {
     if (!this.active) return;
     event.preventDefault();
@@ -332,6 +342,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.root.classList.add('drawio-interactive-resizing');
     this.doc.addEventListener('pointermove', this.onResizeMove);
     this.doc.addEventListener('pointerup', this.onResizeEnd);
+    this.doc.addEventListener('pointercancel', this.onResizeEnd);
   };
 
   private onResizeMove = (event: PointerEvent): void => {
@@ -348,6 +359,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.root.classList.remove('drawio-interactive-resizing');
     this.doc.removeEventListener('pointermove', this.onResizeMove);
     this.doc.removeEventListener('pointerup', this.onResizeEnd);
+    this.doc.removeEventListener('pointercancel', this.onResizeEnd);
     this.opts.onHeightCommit?.(Math.round(this.viewportHeight));
   };
 

--- a/src/preview/interactiveViewer.ts
+++ b/src/preview/interactiveViewer.ts
@@ -21,7 +21,7 @@ interface ViewBox {
   height: number;
 }
 
-const ZOOM_STEP = 1.2;
+const ZOOM_STEP = 1.02;
 const MAX_SCALE = 8;
 const SCALE_EPSILON = 0.0001;
 
@@ -76,6 +76,19 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   }
 
   get isActive(): boolean { return this.active; }
+
+  applyPersistedHeight(height: number): void {
+    if (this.disposed) return;
+    const next = clamp(height, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
+    this.opts.initialHeight = next;
+    this.manuallyResized = true;
+    if (!this.svg || !this.baseBox) return;
+    this.preview.classList.add('drawio-interactive-viewport');
+    this.svg.classList.add('drawio-interactive-svg');
+    this.setViewportHeight(next);
+    this.viewportInitialized = true;
+    this.fit();
+  }
 
   bindSvg(svg: SVGSVGElement | null, opts: BindSvgOptions = {}): void {
     const preservedHeight = opts.preserveViewportHeight && this.viewportInitialized

--- a/src/preview/viewportHeight.ts
+++ b/src/preview/viewportHeight.ts
@@ -1,0 +1,99 @@
+import { App, MarkdownPostProcessorContext, TFile } from 'obsidian';
+
+export const MIN_VIEWPORT_HEIGHT = 80;
+export const MAX_VIEWPORT_HEIGHT = 4000;
+
+const COMMENT_RE = /^\s*<!--\s*drawio-viewer:\s*height=(\d+)\s*-->\s*$/;
+const ANY_COMMENT_RE = /^\s*<!--\s*drawio-viewer\s*:/;
+const OPEN_RE = /^\s*(```+|~~~+)\s*drawio\s*$/;
+const CLOSE_RE = /^\s*(```+|~~~+)\s*$/;
+
+export function parseViewportHeightComment(line: string | undefined): number | null {
+  const raw = COMMENT_RE.exec(line ?? '')?.[1];
+  if (!raw) return null;
+  const height = Number(raw);
+  return Number.isInteger(height)
+    ? clampHeight(height)
+    : null;
+}
+
+export function upsertViewportHeightComment(doc: string, blockStart: number, height: number): string {
+  const lines = doc.split('\n');
+  const opening = lines[blockStart] ?? '';
+  const indent = /^\s*/.exec(opening)?.[0] ?? '';
+  const comment = `${indent}<!-- drawio-viewer: height=${clampHeight(height)} -->`;
+  if (blockStart > 0 && ANY_COMMENT_RE.test(lines[blockStart - 1] ?? '')) {
+    lines[blockStart - 1] = comment;
+  } else {
+    lines.splice(blockStart, 0, comment);
+  }
+  return lines.join('\n');
+}
+
+export async function readCodeBlockViewportHeight(
+  app: App,
+  ctx: MarkdownPostProcessorContext,
+  el: HTMLElement,
+  source: string,
+): Promise<number | null> {
+  const file = app.vault?.getAbstractFileByPath?.(ctx.sourcePath);
+  if (!(file instanceof TFile)) return null;
+  const doc = await app.vault.cachedRead(file);
+  const start = resolveBlockStart(doc, ctx, el, source);
+  return start === null ? null : parseViewportHeightComment(doc.split('\n')[start - 1]);
+}
+
+export async function writeCodeBlockViewportHeight(
+  app: App,
+  ctx: MarkdownPostProcessorContext,
+  el: HTMLElement,
+  source: string,
+  height: number,
+): Promise<boolean> {
+  const file = app.vault?.getAbstractFileByPath?.(ctx.sourcePath);
+  if (!(file instanceof TFile)) return false;
+  let changed = false;
+  await app.vault.process(file, (doc) => {
+    const start = resolveBlockStart(doc, ctx, el, source);
+    if (start === null) return doc;
+    changed = true;
+    return upsertViewportHeightComment(doc, start, height);
+  });
+  return changed;
+}
+
+function resolveBlockStart(
+  doc: string,
+  ctx: MarkdownPostProcessorContext,
+  el: HTMLElement,
+  source: string,
+): number | null {
+  const lines = doc.split('\n');
+  const getInfo = (ctx as unknown as {
+    getSectionInfo?: (target: HTMLElement) => { lineStart: number; lineEnd: number } | null;
+  }).getSectionInfo;
+  const info = getInfo?.call(ctx, el);
+  if (info && blockMatches(lines, info.lineStart, info.lineEnd, source)) return info.lineStart;
+
+  const matches: number[] = [];
+  for (let start = 0; start < lines.length; start += 1) {
+    if (!OPEN_RE.test(lines[start] ?? '')) continue;
+    for (let end = start + 1; end < lines.length; end += 1) {
+      if (!CLOSE_RE.test(lines[end] ?? '')) continue;
+      if (blockMatches(lines, start, end, source)) matches.push(start);
+      start = end;
+      break;
+    }
+  }
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+function blockMatches(lines: string[], start: number, end: number, source: string): boolean {
+  return OPEN_RE.test(lines[start] ?? '')
+    && CLOSE_RE.test(lines[end] ?? '')
+    && lines.slice(start + 1, end).join('\n').trim() === source.trim();
+}
+
+function clampHeight(height: number): number {
+  return Math.round(Math.min(MAX_VIEWPORT_HEIGHT, Math.max(MIN_VIEWPORT_HEIGHT, height)));
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,7 +27,7 @@ export interface DrawioSettings {
   readonlyFileView: boolean;
   /** Desktop: what clicking a preview does (embeds and read-only file tabs). */
   previewClickAction: PreviewClickAction;
-  /** Desktop interactive viewer: action used by its explicit Edit button. */
+  /** Desktop interactive viewer: Edit action for file-backed diagrams. */
   editButtonAction: EditButtonAction;
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,8 @@ export type NewDiagramLocation = 'root' | 'current' | 'folder';
  * everywhere, editable here). */
 export type NewDiagramFormat = 'drawio' | 'svg' | 'png';
 export type PreviewAlignment = 'center' | 'left';
-export type PreviewClickAction = 'editor' | 'defaultApp' | 'none';
+export type PreviewClickAction = 'editor' | 'defaultApp' | 'interactive' | 'none';
+export type EditButtonAction = 'editor' | 'defaultApp';
 
 export interface DrawioSettings {
   drawioMode: DrawioMode;
@@ -26,6 +27,8 @@ export interface DrawioSettings {
   readonlyFileView: boolean;
   /** Desktop: what clicking a preview does (embeds and read-only file tabs). */
   previewClickAction: PreviewClickAction;
+  /** Desktop interactive viewer: action used by its explicit Edit button. */
+  editButtonAction: EditButtonAction;
 }
 
 export const DEFAULT_SETTINGS: DrawioSettings = {
@@ -43,4 +46,5 @@ export const DEFAULT_SETTINGS: DrawioSettings = {
   previewAlignment: 'center',
   readonlyFileView: false,
   previewClickAction: 'editor',
+  editButtonAction: 'editor',
 };

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -3,7 +3,8 @@ import type DrawioPlugin from './main';
 import { DRAWIO_VERSION } from './constants';
 import { formatInstallProgress, type WebappInstallState } from './model/installStatus';
 import type {
-  DrawioMode, NewDiagramFormat, NewDiagramLocation, PreviewAlignment, PreviewClickAction,
+  DrawioMode, EditButtonAction, NewDiagramFormat, NewDiagramLocation,
+  PreviewAlignment, PreviewClickAction,
 } from './settings';
 
 /**
@@ -118,15 +119,34 @@ export class DrawioSettingTab extends PluginSettingTab {
         .setName('Preview click action')
         .setDesc(
           'What clicking a diagram preview does (embeds and read-only file tabs). Code blocks ' +
-          'have no underlying file, so they always open the built-in editor unless ' +
-          '"Do nothing" is selected.',
+          'have no underlying file, so opening the system default app falls back to the ' +
+          'built-in editor.',
         )
         .addDropdown((d) => d
           .addOption('editor', 'Open built-in editor')
           .addOption('defaultApp', 'Open in system default app')
+          .addOption('interactive', 'Interactive viewer')
           .addOption('none', 'Do nothing')
           .setValue(s.previewClickAction)
-          .onChange((v) => { s.previewClickAction = v as PreviewClickAction; save(); }));
+          .onChange((v) => {
+            s.previewClickAction = v as PreviewClickAction;
+            save();
+            this.display();
+          }));
+
+      if (s.previewClickAction === 'interactive') {
+        new Setting(containerEl)
+          .setName('Edit button action')
+          .setDesc(
+            'What the interactive viewer Edit button does. Code blocks have no underlying ' +
+            'file, so the system default app falls back to the built-in editor.',
+          )
+          .addDropdown((d) => d
+            .addOption('editor', 'Open built-in editor')
+            .addOption('defaultApp', 'Open in system default app')
+            .setValue(s.editButtonAction)
+            .onChange((v) => { s.editButtonAction = v as EditButtonAction; save(); }));
+      }
     }
 
     new Setting(containerEl)

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,4 +1,6 @@
-import { App, ButtonComponent, Platform, PluginSettingTab, Setting } from 'obsidian';
+import {
+  App, ButtonComponent, DropdownComponent, Platform, PluginSettingTab, Setting,
+} from 'obsidian';
 import type DrawioPlugin from './main';
 import { DRAWIO_VERSION } from './constants';
 import { formatInstallProgress, type WebappInstallState } from './model/installStatus';
@@ -135,17 +137,33 @@ export class DrawioSettingTab extends PluginSettingTab {
           }));
 
       if (s.previewClickAction === 'interactive') {
-        new Setting(containerEl)
+        const editActionSetting = new Setting(containerEl)
           .setName('Edit button action')
           .setDesc(
-            'What the interactive viewer Edit button does. Code blocks have no underlying ' +
-            'file, so the system default app falls back to the built-in editor.',
-          )
-          .addDropdown((d) => d
-            .addOption('editor', 'Open built-in editor')
-            .addOption('defaultApp', 'Open in system default app')
-            .setValue(s.editButtonAction)
-            .onChange((v) => { s.editButtonAction = v as EditButtonAction; save(); }));
+            'How the Interactive Viewer Edit button opens file-backed and inline diagrams.',
+          );
+        editActionSetting.settingEl.addClass('drawio-edit-action-settings');
+        const fields = editActionSetting.settingEl.createDiv({ cls: 'drawio-edit-action-fields' });
+        const addField = (label: string, description: string): HTMLElement => {
+          const row = fields.createDiv({ cls: 'drawio-edit-action-row' });
+          const text = row.createDiv({ cls: 'drawio-edit-action-text' });
+          text.createDiv({ cls: 'drawio-edit-action-label', text: label });
+          text.createDiv({ cls: 'drawio-edit-action-description', text: description });
+          return row.createDiv({ cls: 'drawio-edit-action-control' });
+        };
+        new DropdownComponent(addField(
+          'File diagrams', 'Embeds and read-only .drawio file views.',
+        ))
+          .addOption('editor', 'Open built-in editor')
+          .addOption('defaultApp', 'Open in system default app')
+          .setValue(s.editButtonAction)
+          .onChange((v) => { s.editButtonAction = v as EditButtonAction; save(); });
+        new DropdownComponent(addField(
+          'Inline code blocks', 'No separate file; always uses the built-in editor.',
+        ))
+          .addOption('editor', 'Open built-in editor')
+          .setValue('editor')
+          .setDisabled(true);
       }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,29 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
   border: 1px solid var(--background-modifier-error); border-radius: 6px;
 }
 
+.drawio-edit-action-settings {
+  flex-wrap: wrap;
+}
+.drawio-edit-action-fields {
+  width: 100%; margin-top: 10px; padding-left: 12px;
+  border-left: 2px solid var(--background-modifier-border);
+}
+.drawio-edit-action-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px; padding: 8px 0;
+}
+.drawio-edit-action-row + .drawio-edit-action-row {
+  border-top: 1px solid var(--background-modifier-border);
+}
+.drawio-edit-action-label { color: var(--text-normal); font-weight: var(--font-semibold); }
+.drawio-edit-action-description { color: var(--text-muted); font-size: var(--font-ui-smaller); }
+.drawio-edit-action-control { flex: 0 0 auto; }
+.drawio-edit-action-control select { max-width: 240px; }
+@media (max-width: 600px) {
+  .drawio-edit-action-row { align-items: stretch; flex-direction: column; gap: 6px; }
+  .drawio-edit-action-control select { width: 100%; max-width: none; }
+}
+
 /* Multi-page navigation, rendered below the diagram when a file has >1 page. */
 .drawio-page-control {
   display: flex; align-items: center; justify-content: center; gap: 8px;

--- a/styles.css
+++ b/styles.css
@@ -53,15 +53,32 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
   padding: 4px; border: 1px solid var(--background-modifier-border);
   border-radius: 6px; background: var(--background-secondary);
   box-shadow: 0 2px 8px rgba(0, 0, 0, .2);
+  opacity: .58; transition: opacity .15s ease;
 }
 .drawio-interactive-active .drawio-interactive-toolbar { display: flex; }
+.drawio-interactive-toolbar:hover,
+.drawio-interactive-toolbar:focus-within { opacity: 1; }
 .drawio-edit-hint[hidden] { display: none !important; }
 .drawio-interactive-active.drawio-interactive-zoomed .drawio-interactive-viewport { cursor: grab; }
 .drawio-interactive-panning .drawio-interactive-viewport { cursor: grabbing; }
 .drawio-interactive-toolbar button {
   margin: 0; padding: 3px 7px; font-size: var(--font-ui-small);
+  transition: background-color .1s ease, color .1s ease, transform .06s ease;
+}
+.drawio-interactive-toolbar button:not(:disabled):hover {
+  background: var(--background-modifier-hover);
+}
+.drawio-interactive-toolbar button:not(:disabled):focus-visible {
+  outline: 2px solid var(--interactive-accent); outline-offset: 1px;
+}
+.drawio-interactive-toolbar button:not(:disabled):active {
+  color: var(--text-on-accent); background: var(--interactive-accent);
+  transform: scale(.94);
 }
 .drawio-interactive-toolbar button[hidden] { display: none !important; }
+@media (hover: none) {
+  .drawio-interactive-toolbar { opacity: 1; }
+}
 .drawio-interactive-resize-handle {
   position: absolute; z-index: 3; left: 0; right: 0;
   display: none; height: 10px; cursor: ns-resize;

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,46 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
 /* Previews whose click action is "Do nothing" shouldn't advertise clickability. */
 .drawio-codeblock.drawio-no-action, .drawio-embed.drawio-no-action { cursor: default; }
 
+/* Interactive viewer viewport and controls. */
+.drawio-interactive .drawio-preview { user-select: none; }
+.drawio-interactive-active .drawio-interactive-viewport {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 2px var(--interactive-accent);
+}
+.drawio-interactive-viewport .drawio-interactive-svg {
+  width: 100%; height: 100%; max-width: none;
+  margin: 0; display: block;
+}
+.drawio-interactive-toolbar {
+  position: absolute; z-index: 2; top: 8px; right: 8px;
+  display: none; align-items: center; gap: 4px;
+  padding: 4px; border: 1px solid var(--background-modifier-border);
+  border-radius: 6px; background: var(--background-secondary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .2);
+}
+.drawio-interactive-active .drawio-interactive-toolbar { display: flex; }
+.drawio-interactive-active .drawio-edit-hint { opacity: 0; }
+.drawio-interactive-active.drawio-interactive-zoomed .drawio-interactive-viewport { cursor: grab; }
+.drawio-interactive-panning .drawio-interactive-viewport { cursor: grabbing; }
+.drawio-interactive-toolbar button {
+  margin: 0; padding: 3px 7px; font-size: var(--font-ui-small);
+}
+.drawio-interactive-resize-handle {
+  position: absolute; z-index: 3; left: 0; right: 0;
+  display: none; height: 10px; cursor: ns-resize;
+}
+.drawio-interactive-resize-handle::after {
+  content: ''; position: absolute; left: 50%; bottom: 2px;
+  width: 48px; height: 3px; transform: translateX(-50%);
+  border-radius: 2px; background: var(--interactive-accent);
+  opacity: .7;
+}
+.drawio-interactive-active .drawio-interactive-resize-handle { display: block; }
+.drawio-interactive-resizing { cursor: ns-resize; }
+
 .drawio-error {
   padding: 8px 12px; color: var(--text-error);
   border: 1px solid var(--background-modifier-error); border-radius: 6px;

--- a/styles.css
+++ b/styles.css
@@ -55,12 +55,13 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
   box-shadow: 0 2px 8px rgba(0, 0, 0, .2);
 }
 .drawio-interactive-active .drawio-interactive-toolbar { display: flex; }
-.drawio-interactive-active .drawio-edit-hint { opacity: 0; }
+.drawio-edit-hint[hidden] { display: none !important; }
 .drawio-interactive-active.drawio-interactive-zoomed .drawio-interactive-viewport { cursor: grab; }
 .drawio-interactive-panning .drawio-interactive-viewport { cursor: grabbing; }
 .drawio-interactive-toolbar button {
   margin: 0; padding: 3px 7px; font-size: var(--font-ui-small);
 }
+.drawio-interactive-toolbar button[hidden] { display: none !important; }
 .drawio-interactive-resize-handle {
   position: absolute; z-index: 3; left: 0; right: 0;
   display: none; height: 10px; cursor: ns-resize;
@@ -73,6 +74,15 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
 }
 .drawio-interactive-active .drawio-interactive-resize-handle { display: block; }
 .drawio-interactive-resizing { cursor: ns-resize; }
+.drawio-interactive-fullscreen {
+  box-sizing: border-box; display: flex; flex-direction: column;
+  width: 100%; height: 100%; padding: 12px;
+  background: var(--background-primary);
+}
+.drawio-interactive-fullscreen .drawio-interactive-viewport {
+  flex: 1 1 auto; min-height: 0; height: auto !important;
+}
+.drawio-interactive-fullscreen .drawio-interactive-resize-handle { display: none; }
 
 .drawio-error {
   padding: 8px 12px; color: var(--text-error);

--- a/tests/clickAction.test.ts
+++ b/tests/clickAction.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { App } from 'obsidian';
-import { resolveClickAction, openWithDefaultApp } from '../src/preview/clickAction';
+import {
+  resolveClickAction, resolveEditButtonAction, openWithDefaultApp,
+} from '../src/preview/clickAction';
 
 describe('resolveClickAction', () => {
   it('maps "editor" to the built-in editor on every surface', () => {
@@ -32,6 +34,26 @@ describe('resolveClickAction', () => {
       expect(r.hint).toBeUndefined();
       expect(r.title).toBe('Drawio diagram');
     }
+  });
+
+  it('maps "interactive" to activation without opening an editor', () => {
+    for (const surface of ['codeblock', 'file'] as const) {
+      const r = resolveClickAction('interactive', surface);
+      expect(r.kind).toBe('interactive');
+      expect(r.hint).toEqual({ label: 'Explore', icon: 'move' });
+      expect(r.title).toBe('Click to explore diagram');
+    }
+  });
+});
+
+describe('resolveEditButtonAction', () => {
+  it('opens the selected editor action for file-backed previews', () => {
+    expect(resolveEditButtonAction('editor', 'file').kind).toBe('editor');
+    expect(resolveEditButtonAction('defaultApp', 'file').kind).toBe('defaultApp');
+  });
+
+  it('falls back to the built-in editor for code blocks', () => {
+    expect(resolveEditButtonAction('defaultApp', 'codeblock').kind).toBe('editor');
   });
 });
 

--- a/tests/drawioCodeBlockMobile.test.ts
+++ b/tests/drawioCodeBlockMobile.test.ts
@@ -4,13 +4,23 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 // jsdom-eval incompatibilities in the real vendored viewer (see
 // tests/drawioMobileFileView.test.ts for the same pattern).
 vi.mock('../src/preview/viewer.min.txt', () => ({ default: 'window.GraphViewer = window.GraphViewer || undefined;' }));
+vi.mock('../src/preview/ViewerRenderer', () => ({
+  renderPreview: (el: HTMLElement, _xml: string, opts: { page?: number }) => {
+    el.empty();
+    const svg = el.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', opts.page === 1 ? '10 20 400 300' : '0 0 200 100');
+    svg.dataset.page = String(opts.page ?? 0);
+    el.appendChild(svg);
+    return true;
+  },
+}));
 
 import { Platform } from 'obsidian';
 import { registerDrawioCodeBlock } from '../src/codeblock/DrawioCodeBlock';
 import type { PreviewClickAction } from '../src/settings';
 import type DrawioPlugin from '../src/main';
 
-type Processor = (source: string, el: HTMLElement, ctx: unknown) => void;
+type Processor = (source: string, el: HTMLElement, ctx: unknown) => void | Promise<void>;
 
 function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: PreviewClickAction = 'editor') {
   let processor: Processor | undefined;
@@ -23,58 +33,110 @@ function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: 
   };
   return {
     plugin: raw as unknown as DrawioPlugin,
-    run: (source: string, el: HTMLElement, ctx: unknown) => processor!(source, el, ctx),
+    run: async (source: string, el: HTMLElement, ctx: unknown) => processor!(source, el, {
+      ...(ctx as object),
+      addChild: vi.fn(),
+    }),
   };
 }
 
 const XML = '<mxfile><diagram id="0" name="Page-1"><mxGraphModel/></diagram></mxfile>';
+const MULTI_PAGE_XML = '<mxfile>' +
+  '<diagram id="0" name="Page-1"><mxGraphModel/></diagram>' +
+  '<diagram id="1" name="Page-2"><mxGraphModel/></diagram>' +
+  '</mxfile>';
 
 describe('drawio code block — mobile click behavior', () => {
   const originalIsDesktopApp = Platform.isDesktopApp;
   afterEach(() => { Platform.isDesktopApp = originalIsDesktopApp; });
 
-  it('opens the editor on click and shows the edit hint on desktop', () => {
+  it('opens the editor on click and shows the edit hint on desktop', async () => {
     Platform.isDesktopApp = true;
     const openEditor = vi.fn();
     const { plugin, run } = fakePlugin(openEditor);
     registerDrawioCodeBlock(plugin);
     const el = document.createElement('div');
-    run(XML, el, { sourcePath: 'note.md' });
+    await run(XML, el, { sourcePath: 'note.md' });
     el.querySelector('.drawio-codeblock')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(openEditor).toHaveBeenCalledTimes(1);
     expect(el.querySelector('.drawio-edit-hint')).not.toBeNull();
   });
 
-  it('still opens the built-in editor under "defaultApp" (code blocks have no file)', () => {
+  it('still opens the built-in editor under "defaultApp" (code blocks have no file)', async () => {
     Platform.isDesktopApp = true;
     const openEditor = vi.fn();
     const { plugin, run } = fakePlugin(openEditor, 'defaultApp');
     registerDrawioCodeBlock(plugin);
     const el = document.createElement('div');
-    run(XML, el, { sourcePath: 'note.md' });
+    await run(XML, el, { sourcePath: 'note.md' });
     el.querySelector('.drawio-codeblock')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(openEditor).toHaveBeenCalledTimes(1);
   });
 
-  it('does nothing on click under "none", with no edit hint', () => {
+  it('does nothing on click under "none", with no edit hint', async () => {
     Platform.isDesktopApp = true;
     const openEditor = vi.fn();
     const { plugin, run } = fakePlugin(openEditor, 'none');
     registerDrawioCodeBlock(plugin);
     const el = document.createElement('div');
-    run(XML, el, { sourcePath: 'note.md' });
+    await run(XML, el, { sourcePath: 'note.md' });
     el.querySelector('.drawio-codeblock')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(openEditor).not.toHaveBeenCalled();
     expect(el.querySelector('.drawio-edit-hint')).toBeNull();
   });
 
-  it('shows a Notice instead of opening the editor on mobile, with no edit hint', () => {
+  it('mounts the walking skeleton without opening the editor under "interactive"', async () => {
+    Platform.isDesktopApp = true;
+    const openEditor = vi.fn();
+    const { plugin, run } = fakePlugin(openEditor, 'interactive');
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md' });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    wrapper.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(wrapper.classList.contains('drawio-interactive-active')).toBe(true);
+    expect(wrapper.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+    expect(openEditor).not.toHaveBeenCalled();
+  });
+
+  it('rebinds the viewer after a page change without changing the viewport height', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(MULTI_PAGE_XML, el, { sourcePath: 'note.md' });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    const preview = wrapper.querySelector<HTMLElement>('.drawio-preview')!;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const handle = wrapper.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 420 }));
+    const height = preview.style.height;
+    const firstSvg = preview.querySelector('svg');
+
+    const pageButtons = wrapper.querySelectorAll<HTMLButtonElement>('.drawio-page-control button');
+    pageButtons[1]!.click();
+    const replacement = preview.querySelector('svg')!;
+
+    expect(replacement).not.toBe(firstSvg);
+    expect(replacement.dataset.page).toBe('1');
+    expect(replacement.getAttribute('viewBox')).toBe('10 20 400 300');
+    expect(replacement.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(preview.style.height).toBe(height);
+    expect(wrapper.classList.contains('drawio-interactive-active')).toBe(false);
+    expect(wrapper.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+  });
+
+  it('shows a Notice instead of opening the editor on mobile, with no edit hint', async () => {
     Platform.isDesktopApp = false;
     const openEditor = vi.fn();
     const { plugin, run } = fakePlugin(openEditor);
     registerDrawioCodeBlock(plugin);
     const el = document.createElement('div');
-    run(XML, el, { sourcePath: 'note.md' });
+    await run(XML, el, { sourcePath: 'note.md' });
     el.querySelector('.drawio-codeblock')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(openEditor).not.toHaveBeenCalled();
     expect(el.querySelector('.drawio-edit-hint')).toBeNull();

--- a/tests/drawioCodeBlockMobile.test.ts
+++ b/tests/drawioCodeBlockMobile.test.ts
@@ -26,7 +26,7 @@ function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: 
   let processor: Processor | undefined;
   const raw = {
     app: {},
-    settings: { previewClickAction },
+    settings: { previewClickAction, editButtonAction: 'editor' },
     previewOpts: () => ({ dark: false }),
     openEditor,
     registerMarkdownCodeBlockProcessor: (_lang: string, cb: Processor) => { processor = cb; },
@@ -97,7 +97,27 @@ describe('drawio code block — mobile click behavior', () => {
       .dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(wrapper.classList.contains('drawio-interactive-active')).toBe(true);
     expect(wrapper.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+    const explore = wrapper.querySelector<HTMLElement>('.drawio-edit-hint')!;
+    expect(explore.hidden).toBe(true);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(explore.hidden).toBe(false);
     expect(openEditor).not.toHaveBeenCalled();
+  });
+
+  it('opens the built-in editor from the interactive toolbar Edit button', async () => {
+    Platform.isDesktopApp = true;
+    const openEditor = vi.fn();
+    const { plugin, run } = fakePlugin(openEditor, 'interactive');
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md' });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    wrapper.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    wrapper.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+
+    expect(openEditor).toHaveBeenCalledTimes(1);
   });
 
   it('rebinds the viewer after a page change without changing the viewport height', async () => {

--- a/tests/drawioPreviewFileView.test.ts
+++ b/tests/drawioPreviewFileView.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 
 // Mock the viewer.min.txt file to avoid needing to fetch it
 vi.mock('../src/preview/viewer.min.txt', () => ({ default: 'window.GraphViewer = window.GraphViewer || undefined;' }));
+vi.mock('../src/preview/ViewerRenderer', () => ({
+  renderPreview: (el: HTMLElement, _xml: string, opts: { page?: number }) => {
+    el.empty();
+    const svg = el.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', opts.page === 1 ? '10 20 400 300' : '0 0 200 100');
+    svg.dataset.page = String(opts.page ?? 0);
+    el.appendChild(svg);
+    return true;
+  },
+}));
 
 import { Platform, TFile } from 'obsidian';
 import { DrawioPreviewFileView } from '../src/preview/DrawioPreviewFileView';
@@ -15,7 +25,7 @@ function fakePlugin(
 ): DrawioPlugin {
   return {
     app,
-    settings: { previewClickAction },
+    settings: { previewClickAction, editButtonAction: 'editor' },
     previewOpts: () => ({ dark: false }),
     openEditor,
   } as unknown as DrawioPlugin;
@@ -100,6 +110,34 @@ describe('DrawioPreviewFileView', () => {
     view.contentEl.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(openEditor).not.toHaveBeenCalled();
     expect(openWithDefaultApp).not.toHaveBeenCalled();
+  });
+
+  it('mounts the interactive viewer and routes its Edit button', () => {
+    Platform.isDesktopApp = true;
+    const openEditor = vi.fn();
+    const view = makeView(fakePlugin('interactive', openEditor));
+    view.setViewData(XML, true);
+    const preview = view.contentEl.querySelector<HTMLElement>('.drawio-preview')!;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(view.contentEl.classList.contains('drawio-interactive-active')).toBe(true);
+    expect(view.contentEl.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+    view.contentEl.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+    expect(openEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebinds the interactive viewer after a file-view page flip', () => {
+    Platform.isDesktopApp = true;
+    const view = makeView(fakePlugin('interactive'));
+    view.setViewData(MULTI_PAGE_XML, true);
+    const preview = view.contentEl.querySelector<HTMLElement>('.drawio-preview')!;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const height = preview.style.height;
+    view.contentEl.querySelectorAll<HTMLButtonElement>('.drawio-page-control button')[1]!.click();
+    const replacement = preview.querySelector('svg')!;
+    expect(replacement.dataset.page).toBe('1');
+    expect(replacement.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(preview.style.height).toBe(height);
+    expect(view.contentEl.classList.contains('drawio-interactive-active')).toBe(false);
   });
 
   it('renders the page switcher for multi-page diagrams', () => {

--- a/tests/embedInteractiveFallback.dom.test.ts
+++ b/tests/embedInteractiveFallback.dom.test.ts
@@ -36,7 +36,7 @@ function harness() {
     settings: { previewClickAction: 'interactive', editButtonAction: 'editor' },
     previewOpts: () => ({ dark: false }),
     app: {
-      vault: { read: () => Promise.resolve(XML) },
+      vault: { read: () => Promise.resolve(XML), on: vi.fn(() => ({})) },
       metadataCache: { getFirstLinkpathDest: () => file },
     },
     registerMarkdownPostProcessor: (fn: Processor) => { processor = fn; },

--- a/tests/embedInteractiveFallback.dom.test.ts
+++ b/tests/embedInteractiveFallback.dom.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/preview/viewer.min.txt', () => ({
+  default: 'window.GraphViewer = window.GraphViewer || undefined;',
+}));
+vi.mock('../src/preview/ViewerRenderer', () => ({
+  renderPreview: (el: HTMLElement, _xml: string, opts: { page?: number }) => {
+    el.empty();
+    const svg = el.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', opts.page === 1 ? '10 20 400 300' : '0 0 200 100');
+    svg.dataset.page = String(opts.page ?? 0);
+    el.appendChild(svg);
+    return true;
+  },
+}));
+
+import { TFile } from 'obsidian';
+import { registerDrawioEmbeds } from '../src/file/EmbedRenderer';
+import type DrawioPlugin from '../src/main';
+
+const XML = '<mxfile>' +
+  '<diagram id="0" name="Page-1"><mxGraphModel/></diagram>' +
+  '<diagram id="1" name="Page-2"><mxGraphModel/></diagram>' +
+  '</mxfile>';
+
+type Processor = (
+  el: HTMLElement,
+  ctx: { sourcePath: string; addChild: (child: unknown) => void },
+) => void;
+
+function harness() {
+  let processor: Processor | undefined;
+  const openEditor = vi.fn();
+  const file = Object.assign(new TFile(), { path: 'diagram.drawio', basename: 'diagram' });
+  const plugin = {
+    settings: { previewClickAction: 'interactive', editButtonAction: 'editor' },
+    previewOpts: () => ({ dark: false }),
+    app: {
+      vault: { read: () => Promise.resolve(XML) },
+      metadataCache: { getFirstLinkpathDest: () => file },
+    },
+    registerMarkdownPostProcessor: (fn: Processor) => { processor = fn; },
+    openEditor,
+  } as unknown as DrawioPlugin;
+  registerDrawioEmbeds(plugin);
+  return { processor: () => processor!, openEditor };
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => { window.setTimeout(resolve, 0); });
+}
+
+describe('interactive embed fallback renderer', () => {
+  it('mounts the controller, routes Edit, and rebinds page changes', async () => {
+    const { processor, openEditor } = harness();
+    const section = document.body.createDiv();
+    const span = section.createSpan({ cls: 'internal-embed' });
+    span.setAttribute('src', 'diagram.drawio');
+    const addChild = vi.fn();
+    processor()(section, { sourcePath: 'note.md', addChild });
+    await tick();
+
+    const preview = span.querySelector<HTMLElement>('.drawio-preview')!;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(span.classList.contains('drawio-interactive-active')).toBe(true);
+    expect(span.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+    expect(addChild).toHaveBeenCalledTimes(1);
+    span.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+    expect(openEditor).toHaveBeenCalledTimes(1);
+
+    span.querySelectorAll<HTMLButtonElement>('.drawio-page-control button')[1]!.click();
+    expect(preview.querySelector<SVGSVGElement>('svg')!.dataset.page).toBe('1');
+    expect(preview.querySelector('svg')!.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(span.classList.contains('drawio-interactive-active')).toBe(false);
+  });
+});

--- a/tests/embedPin.dom.test.ts
+++ b/tests/embedPin.dom.test.ts
@@ -19,7 +19,10 @@ type Creator = (
   subpath?: string,
 ) => { loadFile: () => Promise<void> };
 
-type PostProcessor = (el: HTMLElement, ctx: { sourcePath: string }) => void;
+type PostProcessor = (
+  el: HTMLElement,
+  ctx: { sourcePath: string; addChild: (child: unknown) => void },
+) => void;
 
 // `registry: false` omits the embedRegistry so registerDrawioEmbeds falls
 // back to the reading-view post-processor (exercised in the fallback suite).
@@ -111,7 +114,7 @@ describe('embed pin wiring (post-processor fallback path)', () => {
     const section = document.body.createDiv();
     const span = section.createSpan({ cls: 'internal-embed' });
     span.setAttribute('src', 'multi.drawio');
-    postProcessor!(section, { sourcePath: 'note.md' });
+    postProcessor!(section, { sourcePath: 'note.md', addChild: () => {} });
     await tick();
 
     const [, next] = Array.from(span.querySelectorAll<HTMLButtonElement>('.drawio-page-control button'));

--- a/tests/embedRendererMobile.test.ts
+++ b/tests/embedRendererMobile.test.ts
@@ -244,6 +244,24 @@ describe('drawio embed — mobile click behavior', () => {
     raf.mockRestore();
   });
 
+  it('does not read persisted height outside Interactive Viewer mode', async () => {
+    Platform.isDesktopApp = true;
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const { plugin, create } = fakePlugin(vi.fn(), 'editor');
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    await create(containerEl, 'note.md').loadFile();
+    frames.shift()?.(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(heightMetadata.read).not.toHaveBeenCalled();
+    raf.mockRestore();
+  });
+
   it('passes the duplicate embed occurrence from the current Markdown surface', async () => {
     Platform.isDesktopApp = true;
     const { plugin, create } = fakePlugin(vi.fn(), 'interactive');

--- a/tests/embedRendererMobile.test.ts
+++ b/tests/embedRendererMobile.test.ts
@@ -4,6 +4,16 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 // jsdom-eval incompatibilities in the real vendored viewer (see
 // tests/drawioMobileFileView.test.ts for the same pattern).
 vi.mock('../src/preview/viewer.min.txt', () => ({ default: 'window.GraphViewer = window.GraphViewer || undefined;' }));
+vi.mock('../src/preview/ViewerRenderer', () => ({
+  renderPreview: (el: HTMLElement, _xml: string, opts: { page?: number }) => {
+    el.empty();
+    const svg = el.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', opts.page === 1 ? '10 20 400 300' : '0 0 200 100');
+    svg.dataset.page = String(opts.page ?? 0);
+    el.appendChild(svg);
+    return true;
+  },
+}));
 
 import { Platform, TFile } from 'obsidian';
 import { registerDrawioEmbeds } from '../src/file/EmbedRenderer';
@@ -11,10 +21,18 @@ import type { PreviewClickAction } from '../src/settings';
 import type DrawioPlugin from '../src/main';
 
 const XML = '<mxfile><diagram id="0" name="Page-1"><mxGraphModel/></diagram></mxfile>';
+const MULTI_PAGE_XML = '<mxfile>' +
+  '<diagram id="0" name="Page-1"><mxGraphModel/></diagram>' +
+  '<diagram id="1" name="Page-2"><mxGraphModel/></diagram>' +
+  '</mxfile>';
 
 type Creator = (ctx: { containerEl: HTMLElement }, file: TFile, subpath?: string) => { loadFile: () => Promise<void> };
 
-function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: PreviewClickAction = 'editor') {
+function fakePlugin(
+  openEditor: DrawioPlugin['openEditor'],
+  previewClickAction: PreviewClickAction = 'editor',
+  xml = XML,
+) {
   let creator: Creator | undefined;
   const openWithDefaultApp = vi.fn();
   const file = Object.assign(new TFile(), { path: 'diagram.drawio', basename: 'diagram' });
@@ -23,10 +41,10 @@ function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: 
       embedRegistry: {
         registerExtension: (_ext: string, c: Creator) => { creator = c; },
       },
-      vault: { read: async () => XML, on: vi.fn(() => ({})) },
+      vault: { read: async () => xml, on: vi.fn(() => ({})) },
       openWithDefaultApp,
     },
-    settings: { previewClickAction },
+    settings: { previewClickAction, editButtonAction: 'editor' },
     previewOpts: () => ({ dark: false }),
     openEditor,
     register: vi.fn(),
@@ -80,6 +98,80 @@ describe('drawio embed — mobile click behavior', () => {
     expect(openEditor).not.toHaveBeenCalled();
     expect(openWithDefaultApp).not.toHaveBeenCalled();
     expect(containerEl.querySelector('.drawio-edit-hint')).toBeNull();
+  });
+
+  it('mounts the interactive viewer and opens the file editor from its Edit button', async () => {
+    Platform.isDesktopApp = true;
+    const openEditor = vi.fn();
+    const { plugin, create } = fakePlugin(openEditor, 'interactive');
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    const embed = create(containerEl);
+    await embed.loadFile();
+
+    containerEl.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(containerEl.classList.contains('drawio-interactive-active')).toBe(true);
+    expect(containerEl.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+    expect(containerEl.querySelector<HTMLElement>('.drawio-edit-hint')!.hidden).toBe(true);
+    containerEl.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+    expect(openEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes the interactive Edit button to the system app for file embeds', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create, openWithDefaultApp } = fakePlugin(vi.fn(), 'interactive');
+    plugin.settings.editButtonAction = 'defaultApp';
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    const embed = create(containerEl);
+    await embed.loadFile();
+    containerEl.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    containerEl.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+    expect(openWithDefaultApp).toHaveBeenCalledWith('diagram.drawio');
+  });
+
+  it('keeps activation state isolated between two embeds', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioEmbeds(plugin);
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    await create(first).loadFile();
+    await create(second).loadFile();
+
+    first.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(first.classList.contains('drawio-interactive-active')).toBe(true);
+    expect(second.classList.contains('drawio-interactive-active')).toBe(false);
+    expect(first.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+    expect(second.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+  });
+
+  it('rebinds a multi-page embed without changing its viewport height', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive', MULTI_PAGE_XML);
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    const embed = create(containerEl);
+    await embed.loadFile();
+    const preview = containerEl.querySelector<HTMLElement>('.drawio-preview')!;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = containerEl.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 420 }));
+    const height = preview.style.height;
+
+    const buttons = containerEl.querySelectorAll<HTMLButtonElement>('.drawio-page-control button');
+    buttons[1]!.click();
+    const replacement = preview.querySelector('svg')!;
+    expect(replacement.dataset.page).toBe('1');
+    expect(replacement.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(preview.style.height).toBe(height);
+    expect(containerEl.classList.contains('drawio-interactive-active')).toBe(false);
+    expect(containerEl.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
   });
 
   it('shows a Notice instead of opening the editor on mobile, with no edit hint', async () => {

--- a/tests/embedRendererMobile.test.ts
+++ b/tests/embedRendererMobile.test.ts
@@ -14,6 +14,23 @@ vi.mock('../src/preview/ViewerRenderer', () => ({
     return true;
   },
 }));
+const heightMetadata = vi.hoisted(() => ({
+  read: vi.fn((_app: unknown, _sourcePath: string) => Promise.resolve<number | null>(null)),
+  write: vi.fn((
+    _app: unknown,
+    _sourcePath: string,
+    _file: unknown,
+    _subpath: string | undefined,
+    _height: number,
+    _ctx?: unknown,
+    _el?: HTMLElement,
+    _occurrence?: number,
+  ) => Promise.resolve<'written'>('written')),
+}));
+vi.mock('../src/preview/embedViewportHeight', () => ({
+  readEmbedViewportHeight: heightMetadata.read,
+  writeEmbedViewportHeight: heightMetadata.write,
+}));
 
 import { Platform, TFile } from 'obsidian';
 import { registerDrawioEmbeds } from '../src/file/EmbedRenderer';
@@ -26,7 +43,11 @@ const MULTI_PAGE_XML = '<mxfile>' +
   '<diagram id="1" name="Page-2"><mxGraphModel/></diagram>' +
   '</mxfile>';
 
-type Creator = (ctx: { containerEl: HTMLElement }, file: TFile, subpath?: string) => { loadFile: () => Promise<void> };
+type Creator = (
+  ctx: { containerEl: HTMLElement; sourcePath?: string },
+  file: TFile,
+  subpath?: string,
+) => { loadFile: () => Promise<void> };
 
 function fakePlugin(
   openEditor: DrawioPlugin['openEditor'],
@@ -51,14 +72,21 @@ function fakePlugin(
   };
   return {
     plugin: raw as unknown as DrawioPlugin,
-    create: (containerEl: HTMLElement) => creator!({ containerEl }, file, undefined),
+    create: (containerEl: HTMLElement, sourcePath?: string) =>
+      creator!({ containerEl, sourcePath }, file, undefined),
     openWithDefaultApp,
   };
 }
 
 describe('drawio embed — mobile click behavior', () => {
   const originalIsDesktopApp = Platform.isDesktopApp;
-  afterEach(() => { Platform.isDesktopApp = originalIsDesktopApp; });
+  afterEach(() => {
+    Platform.isDesktopApp = originalIsDesktopApp;
+    heightMetadata.read.mockReset();
+    heightMetadata.read.mockResolvedValue(null);
+    heightMetadata.write.mockReset();
+    heightMetadata.write.mockResolvedValue('written');
+  });
 
   it('opens the editor on click and shows the edit hint on desktop', async () => {
     Platform.isDesktopApp = true;
@@ -172,6 +200,70 @@ describe('drawio embed — mobile click behavior', () => {
     expect(preview.style.height).toBe(height);
     expect(containerEl.classList.contains('drawio-interactive-active')).toBe(false);
     expect(containerEl.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+  });
+
+  it('restores and commits the height of a Markdown embed insertion', async () => {
+    Platform.isDesktopApp = true;
+    heightMetadata.read.mockResolvedValue(360);
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    const embed = create(containerEl, 'note.md');
+    await embed.loadFile();
+    const preview = containerEl.querySelector<HTMLElement>('.drawio-preview')!;
+    expect(preview.style.height).toBe('360px');
+    expect(heightMetadata.read).toHaveBeenCalledTimes(1);
+
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = containerEl.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 360 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 500 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 500 }));
+    expect(heightMetadata.write).toHaveBeenCalledTimes(1);
+    expect(heightMetadata.write.mock.calls[0]?.[1]).toBe('note.md');
+    expect(heightMetadata.write.mock.calls[0]?.[4]).toBe(500);
+  });
+
+  it('re-reads persisted height after the embed is bound to its render surface', async () => {
+    Platform.isDesktopApp = true;
+    heightMetadata.read.mockResolvedValueOnce(null).mockResolvedValueOnce(470);
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    await create(containerEl, 'note.md').loadFile();
+    expect(frames).toHaveLength(1);
+    frames.shift()!(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(containerEl.querySelector<HTMLElement>('.drawio-preview')!.style.height).toBe('470px');
+    raf.mockRestore();
+  });
+
+  it('passes the duplicate embed occurrence from the current Markdown surface', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioEmbeds(plugin);
+    const surface = document.createElement('div');
+    surface.className = 'markdown-source-view';
+    const firstEl = surface.createDiv();
+    const secondEl = surface.createDiv();
+    await create(firstEl, 'note.md').loadFile();
+    await create(secondEl, 'note.md').loadFile();
+
+    secondEl.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = secondEl.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 360 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 520 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 520 }));
+
+    expect(heightMetadata.write).toHaveBeenCalledTimes(1);
+    expect(heightMetadata.write.mock.calls[0]?.[7]).toBe(1);
   });
 
   it('shows a Notice instead of opening the editor on mobile, with no edit hint', async () => {

--- a/tests/embedViewportHeight.test.ts
+++ b/tests/embedViewportHeight.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TFile } from 'obsidian';
+import {
+  readEmbedViewportHeight, writeEmbedViewportHeight,
+} from '../src/preview/embedViewportHeight';
+import type { App, MarkdownPostProcessorContext } from 'obsidian';
+
+function harness(text: string, links: Array<{ link: string; original: string; offset: number }>) {
+  const state = { text };
+  const note = Object.assign(new TFile(), { path: 'note.md', basename: 'note' });
+  const target = Object.assign(new TFile(), { path: 'diagram.drawio', basename: 'diagram' });
+  const app = {
+    vault: {
+      getAbstractFileByPath: (path: string) => path === note.path ? note : null,
+      cachedRead: () => Promise.resolve(state.text),
+      process: (_file: TFile, fn: (data: string) => string) => {
+        state.text = fn(state.text);
+        return Promise.resolve(state.text);
+      },
+    },
+    metadataCache: {
+      getCache: () => ({
+        embeds: links.map((item) => ({
+          link: item.link,
+          original: item.original,
+          position: {
+            start: { offset: item.offset },
+            end: { offset: item.offset + item.original.length },
+          },
+        })),
+      }),
+      getFirstLinkpathDest: () => target,
+    },
+  } as unknown as App;
+  return { app, note, target, state };
+}
+
+describe('embed viewport height Markdown metadata', () => {
+  it('reads and updates the comment without changing subpath or alias', async () => {
+    const embed = '![[diagram.drawio#Page-2|Architecture]]';
+    const text = `<!-- drawio-viewer: height=320 -->\n${embed}`;
+    const { app, target, state } = harness(text, [{ link: 'diagram.drawio#Page-2', original: embed, offset: 43 }]);
+    expect(await readEmbedViewportHeight(app, 'note.md', target, '#Page-2')).toBe(320);
+    expect(await writeEmbedViewportHeight(app, 'note.md', target, '#Page-2', 540)).toBe('written');
+    expect(state.text).toBe(`<!-- drawio-viewer: height=540 -->\n${embed}`);
+  });
+
+  it('keeps two pages of the same file independent', async () => {
+    const first = '![[diagram.drawio#Page-1]]';
+    const second = '![[diagram.drawio#Page-2]]';
+    const text = `${first}\n${second}`;
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio#Page-1', original: first, offset: 0 },
+      { link: 'diagram.drawio#Page-2', original: second, offset: first.length + 1 },
+    ]);
+    expect(await writeEmbedViewportHeight(app, 'note.md', target, '#Page-2', 600)).toBe('written');
+    expect(state.text).toBe(`${first}\n<!-- drawio-viewer: height=600 -->\n${second}`);
+  });
+
+  it('uses the original wikilink subpath when the metadata link omits it', async () => {
+    const first = '![[diagram.drawio#Page-1]]';
+    const second = '![[diagram.drawio#Page-2]]';
+    const text = `${first}\n${second}`;
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio', original: first, offset: 0 },
+      { link: 'diagram.drawio', original: second, offset: first.length + 1 },
+    ]);
+    expect(await writeEmbedViewportHeight(app, 'note.md', target, '#Page-2', 620)).toBe('written');
+    expect(state.text).toBe(`${first}\n<!-- drawio-viewer: height=620 -->\n${second}`);
+  });
+
+  it('refuses to guess between identical duplicate embeds', async () => {
+    const embed = '![[diagram.drawio]]';
+    const text = `${embed}\n${embed}`;
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio', original: embed, offset: 0 },
+      { link: 'diagram.drawio', original: embed, offset: embed.length + 1 },
+    ]);
+    expect(await writeEmbedViewportHeight(app, 'note.md', target, undefined, 700)).toBe('ambiguous');
+    expect(state.text).toBe(text);
+  });
+
+  it('writes the selected occurrence when the render surface identifies it', async () => {
+    const embed = '![[diagram.drawio#Page-1]]';
+    const text = `${embed}\nbetween\n${embed}`;
+    const secondOffset = text.lastIndexOf(embed);
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio', original: embed, offset: 0 },
+      { link: 'diagram.drawio', original: embed, offset: secondOffset },
+    ]);
+    expect(await writeEmbedViewportHeight(
+      app, 'note.md', target, '#Page-1', 680, undefined, undefined, 1,
+    )).toBe('written');
+    expect(state.text).toBe(`${embed}\nbetween\n<!-- drawio-viewer: height=680 -->\n${embed}`);
+  });
+
+  it('uses the Live Preview source offset before the DOM occurrence fallback', async () => {
+    const embed = '![[diagram.drawio#Page-1]]';
+    const text = `${embed}\nbetween\n${embed}`;
+    const secondOffset = text.lastIndexOf(embed);
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio', original: embed, offset: 0 },
+      { link: 'diagram.drawio', original: embed, offset: secondOffset },
+    ]);
+    expect(await writeEmbedViewportHeight(
+      app, 'note.md', target, '#Page-1', 720,
+      undefined, undefined, 0, secondOffset + 1,
+    )).toBe('written');
+    expect(state.text).toBe(`${embed}\nbetween\n<!-- drawio-viewer: height=720 -->\n${embed}`);
+  });
+
+  it('uses section info to distinguish identical embeds in Reading view', async () => {
+    const embed = '![[diagram.drawio]]';
+    const text = `before\n${embed}\nbetween\n${embed}\nafter`;
+    const secondOffset = text.lastIndexOf(embed);
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio', original: embed, offset: text.indexOf(embed) },
+      { link: 'diagram.drawio', original: embed, offset: secondOffset },
+    ]);
+    const el = document.createElement('span');
+    const ctx = {
+      getSectionInfo: vi.fn(() => ({ lineStart: 3, lineEnd: 3 })),
+    } as unknown as MarkdownPostProcessorContext;
+    expect(await writeEmbedViewportHeight(
+      app, 'note.md', target, undefined, 760, ctx, el,
+    )).toBe('written');
+    expect(state.text).toBe(`before\n${embed}\nbetween\n<!-- drawio-viewer: height=760 -->\n${embed}\nafter`);
+  });
+});

--- a/tests/interactiveViewer.dom.test.ts
+++ b/tests/interactiveViewer.dom.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InteractiveViewerController } from '../src/preview/interactiveViewer';
+
+function fixture(): {
+  root: HTMLElement;
+  preview: HTMLElement;
+  svg: SVGSVGElement;
+  controller: InteractiveViewerController;
+} {
+  const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+  const preview = root.createDiv({ cls: 'drawio-preview' });
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 200 100');
+  preview.appendChild(svg);
+  const controller = new InteractiveViewerController(root, preview);
+  controller.bindSvg(svg);
+  return { root, preview, svg, controller };
+}
+
+describe('InteractiveViewerController walking skeleton', () => {
+  it('initializes viewport geometry before activation and the first click does not resize it', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const controller = new InteractiveViewerController(root, preview);
+    controller.bindSvg(svg);
+
+    expect(controller.isActive).toBe(false);
+    expect(preview.style.height).toBe('300px');
+    const heightBeforeClick = preview.style.height;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(true);
+    expect(preview.style.height).toBe(heightBeforeClick);
+    controller.dispose();
+  });
+
+  it('starts inactive and renders zoom, Fit, and disabled Edit controls', () => {
+    const { root, controller } = fixture();
+    expect(controller.isActive).toBe(false);
+    expect(root.classList.contains('drawio-interactive-active')).toBe(false);
+    const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('.drawio-interactive-toolbar button'));
+    expect(buttons.map((button) => button.textContent)).toEqual(['+', '−', 'Fit', 'Edit']);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    controller.dispose();
+  });
+
+  it('activates only when the diagram preview is clicked', () => {
+    const { root, preview, controller } = fixture();
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(false);
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(true);
+    expect(root.classList.contains('drawio-interactive-active')).toBe(true);
+    controller.dispose();
+  });
+
+  it('deactivates on Escape and on a click outside the viewer', () => {
+    const { preview, controller } = fixture();
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(controller.isActive).toBe(false);
+
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(false);
+    controller.dispose();
+  });
+
+  it('intercepts wheel only while active and batches viewBox writes through RAF', () => {
+    const { preview, svg, controller } = fixture();
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 200, height: 100, right: 200, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    const inactiveWheel = new WheelEvent('wheel', { bubbles: true, cancelable: true });
+    preview.dispatchEvent(inactiveWheel);
+    expect(inactiveWheel.defaultPrevented).toBe(false);
+
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const firstWheel = new WheelEvent('wheel', {
+      bubbles: true, cancelable: true, deltaY: -100, clientX: 50, clientY: 25,
+    });
+    const secondWheel = new WheelEvent('wheel', {
+      bubbles: true, cancelable: true, deltaY: -100, clientX: 50, clientY: 25,
+    });
+    preview.dispatchEvent(firstWheel);
+    preview.dispatchEvent(secondWheel);
+    expect(firstWheel.defaultPrevented).toBe(true);
+    expect(frames).toHaveLength(1);
+    expect(svg.getAttribute('viewBox')).toBe('0 0 200 100');
+
+    frames.shift()!(0);
+    const zoomed = svg.getAttribute('viewBox')!.split(' ').map(Number);
+    const x = zoomed[0]!;
+    const y = zoomed[1]!;
+    const width = zoomed[2]!;
+    const height = zoomed[3]!;
+    expect(width).toBeLessThan(170);
+    expect(height).toBeLessThan(85);
+    // The content coordinate under the 25%-from-top-left cursor stays fixed.
+    expect(x + 0.25 * width).toBeCloseTo(50);
+    expect(y + 0.25 * height).toBeCloseTo(25);
+    expect(preview.querySelectorAll('svg')).toHaveLength(1);
+    expect(preview.querySelector('svg')).toBe(svg);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('clamps zoom between Fit and 8x', () => {
+    const { root, preview, svg, controller } = fixture();
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    for (let i = 0; i < 30; i += 1) {
+      preview.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -1 }));
+    }
+    frames.shift()!(0);
+    const limitButtons =
+      Array.from(root.querySelectorAll<HTMLButtonElement>('.drawio-interactive-toolbar button'));
+    const zoomIn = limitButtons[0]!;
+    const zoomOut = limitButtons[1]!;
+    expect(svg.getAttribute('viewBox')!.split(' ').map(Number)[2]).toBeCloseTo(25);
+    expect(zoomIn.disabled).toBe(true);
+    expect(zoomOut.disabled).toBe(false);
+
+    for (let i = 0; i < 30; i += 1) {
+      preview.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 1 }));
+    }
+    frames.shift()!(0);
+    expect(svg.getAttribute('viewBox')).toBe('0 0 200 100');
+    expect(zoomOut.disabled).toBe(true);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('zooms with toolbar controls and Fit restores the original viewBox', () => {
+    const { root, preview, svg, controller } = fixture();
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const toolbarButtons =
+      Array.from(root.querySelectorAll<HTMLButtonElement>('.drawio-interactive-toolbar button'));
+    const zoomIn = toolbarButtons[0]!;
+    const zoomOut = toolbarButtons[1]!;
+    const fit = toolbarButtons[2]!;
+    const edit = toolbarButtons[3]!;
+    expect(zoomIn.disabled).toBe(false);
+    expect(zoomOut.disabled).toBe(true);
+    expect(fit.disabled).toBe(true);
+    expect(edit.disabled).toBe(true);
+
+    zoomIn.click();
+    frames.shift()!(0);
+    expect(svg.getAttribute('viewBox')).not.toBe('0 0 200 100');
+    expect(zoomOut.disabled).toBe(false);
+    expect(fit.disabled).toBe(false);
+
+    fit.click();
+    frames.shift()!(0);
+    expect(svg.getAttribute('viewBox')).toBe('0 0 200 100');
+    expect(zoomOut.disabled).toBe(true);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('creates a full-width viewport using the diagram aspect ratio', () => {
+    const { root, preview, svg, controller } = fixture();
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    window.dispatchEvent(new Event('resize'));
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(preview.classList.contains('drawio-interactive-viewport')).toBe(true);
+    expect(preview.style.height).toBe('300px');
+    expect(svg.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(root.querySelector('.drawio-interactive-resize-handle')).not.toBeNull();
+    controller.dispose();
+  });
+
+  it('limits the automatic viewport by available window height for tall diagrams', () => {
+    const { preview, svg, controller } = fixture();
+    svg.setAttribute('viewBox', '0 0 100 400');
+    controller.bindSvg(svg);
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    const originalHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 700 });
+    window.dispatchEvent(new Event('resize'));
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(preview.style.height).toBe('700px');
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight });
+    controller.dispose();
+  });
+
+  it('resizes the viewport vertically and Fit resets the current zoom', () => {
+    const { root, preview, svg, controller } = fixture();
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 300, right: 600, bottom: 300, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    window.dispatchEvent(new Event('resize'));
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const zoomIn = root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!;
+    zoomIn.click();
+    frames.shift()!(0);
+    expect(svg.getAttribute('viewBox')).not.toBe('0 0 200 100');
+
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 300 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 450 }));
+    expect(preview.style.height).toBe('450px');
+    frames.shift()!(0);
+    expect(svg.getAttribute('viewBox')).toBe('0 0 200 100');
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 450 }));
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('uses a persisted height and commits the final drag height once', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const onHeightCommit = vi.fn();
+    const controller = new InteractiveViewerController(root, preview, {
+      initialHeight: 420,
+      onHeightCommit,
+    });
+    controller.bindSvg(svg);
+    expect(preview.style.height).toBe('420px');
+
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 500 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 520 }));
+    expect(onHeightCommit).not.toHaveBeenCalled();
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 520 }));
+    expect(onHeightCommit).toHaveBeenCalledTimes(1);
+    expect(onHeightCommit).toHaveBeenCalledWith(520);
+    controller.dispose();
+  });
+
+  it('rebinds a replacement page SVG, resets zoom, and preserves viewport height', () => {
+    const { root, preview, svg, controller } = fixture();
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
+
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 420 }));
+    expect(preview.style.height).toBe('420px');
+
+    const replacement = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    replacement.setAttribute('viewBox', '10 20 400 300');
+    preview.empty();
+    preview.appendChild(replacement);
+    controller.bindSvg(replacement, { preserveViewportHeight: true });
+
+    expect(controller.isActive).toBe(false);
+    expect(preview.style.height).toBe('420px');
+    expect(replacement.getAttribute('viewBox')).toBe('10 20 400 300');
+    expect(replacement.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(preview.querySelectorAll('svg')).toHaveLength(1);
+    expect(root.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+    expect(svg.isConnected).toBe(false);
+    controller.dispose();
+  });
+
+  it('pans a zoomed SVG by dragging, clamps to its bounds, and keeps the view after deactivation', () => {
+    const { root, preview, svg, controller } = fixture();
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 200, height: 100, right: 200, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
+    frames.shift()!(0);
+    const zoomed = svg.getAttribute('viewBox')!;
+
+    const start = new MouseEvent('pointerdown', {
+      bubbles: true, cancelable: true, button: 0, clientX: 100, clientY: 50,
+    });
+    preview.dispatchEvent(start);
+    document.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, cancelable: true, clientX: 90, clientY: 45,
+    }));
+    expect(start.defaultPrevented).toBe(true);
+    expect(frames).toHaveLength(1);
+    frames.shift()!(0);
+    const panned = svg.getAttribute('viewBox')!;
+    expect(panned).not.toBe(zoomed);
+    const [x, y] = panned.split(' ').map(Number);
+    expect(x).toBeGreaterThan(0);
+    expect(y).toBeGreaterThan(0);
+
+    document.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, cancelable: true, clientX: 1000, clientY: 1000,
+    }));
+    frames.shift()!(0);
+    expect(svg.getAttribute('viewBox')!.split(' ').slice(0, 2).map(Number)).toEqual([0, 0]);
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(controller.isActive).toBe(false);
+    expect(svg.getAttribute('viewBox')!.split(' ').slice(0, 2).map(Number)).toEqual([0, 0]);
+
+    preview.dispatchEvent(new MouseEvent('pointerdown', {
+      bubbles: true, cancelable: true, button: 0, clientX: 100, clientY: 50,
+    }));
+    document.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, cancelable: true, clientX: 90, clientY: 45,
+    }));
+    frames.shift()!(0);
+    expect(controller.isActive).toBe(true);
+    expect(svg.getAttribute('viewBox')!.split(' ').map(Number)[0]).toBeGreaterThan(0);
+
+    document.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, cancelable: true, clientX: 50, clientY: 25,
+    }));
+    expect(frames).toHaveLength(0);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('removes DOM and listeners when disposed', () => {
+    const { root, preview, controller } = fixture();
+    controller.dispose();
+    expect(root.querySelector('.drawio-interactive-toolbar')).toBeNull();
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(false);
+    expect(root.classList.contains('drawio-interactive')).toBe(false);
+  });
+});

--- a/tests/interactiveViewer.dom.test.ts
+++ b/tests/interactiveViewer.dom.test.ts
@@ -108,8 +108,8 @@ describe('InteractiveViewerController walking skeleton', () => {
     const y = zoomed[1]!;
     const width = zoomed[2]!;
     const height = zoomed[3]!;
-    expect(width).toBeLessThan(170);
-    expect(height).toBeLessThan(85);
+    expect(width).toBeCloseTo(200 / 1.02 ** 2);
+    expect(height).toBeCloseTo(100 / 1.02 ** 2);
     // The content coordinate under the 25%-from-top-left cursor stays fixed.
     expect(x + 0.25 * width).toBeCloseTo(50);
     expect(y + 0.25 * height).toBeCloseTo(25);
@@ -127,7 +127,7 @@ describe('InteractiveViewerController walking skeleton', () => {
       return frames.length;
     });
     preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < 120; i += 1) {
       preview.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -1 }));
     }
     frames.shift()!(0);
@@ -139,7 +139,7 @@ describe('InteractiveViewerController walking skeleton', () => {
     expect(zoomIn.disabled).toBe(true);
     expect(zoomOut.disabled).toBe(false);
 
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < 120; i += 1) {
       preview.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 1 }));
     }
     frames.shift()!(0);
@@ -328,6 +328,13 @@ describe('InteractiveViewerController walking skeleton', () => {
     document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 520 }));
     expect(onHeightCommit).toHaveBeenCalledTimes(1);
     expect(onHeightCommit).toHaveBeenCalledWith(520);
+    controller.dispose();
+  });
+
+  it('applies a persisted height discovered after the SVG was bound', () => {
+    const { preview, controller } = fixture();
+    controller.applyPersistedHeight(560);
+    expect(preview.style.height).toBe('560px');
     controller.dispose();
   });
 

--- a/tests/interactiveViewer.dom.test.ts
+++ b/tests/interactiveViewer.dom.test.ts
@@ -45,7 +45,9 @@ describe('InteractiveViewerController walking skeleton', () => {
     expect(controller.isActive).toBe(false);
     expect(root.classList.contains('drawio-interactive-active')).toBe(false);
     const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('.drawio-interactive-toolbar button'));
-    expect(buttons.map((button) => button.textContent)).toEqual(['+', '−', 'Fit', 'Edit']);
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      '+', '−', 'Fit', 'Edit', 'Full screen', '×',
+    ]);
     expect(buttons.every((button) => button.disabled)).toBe(true);
     controller.dispose();
   });
@@ -161,9 +163,11 @@ describe('InteractiveViewerController walking skeleton', () => {
     const zoomOut = toolbarButtons[1]!;
     const fit = toolbarButtons[2]!;
     const edit = toolbarButtons[3]!;
+    const fullscreen = toolbarButtons[4]!;
     expect(zoomIn.disabled).toBe(false);
     expect(zoomOut.disabled).toBe(true);
     expect(fit.disabled).toBe(true);
+    expect(fullscreen.disabled).toBe(true);
     expect(edit.disabled).toBe(true);
 
     zoomIn.click();
@@ -178,6 +182,66 @@ describe('InteractiveViewerController walking skeleton', () => {
     expect(zoomOut.disabled).toBe(true);
     controller.dispose();
     raf.mockRestore();
+  });
+
+  it('runs the explicit Edit action without triggering the preview click action', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const onEdit = vi.fn();
+    const controller = new InteractiveViewerController(root, preview, { onEdit });
+    controller.bindSvg(svg);
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    root.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(controller.isActive).toBe(true);
+    controller.dispose();
+  });
+
+  it('enters and exits fullscreen through the preview document', () => {
+    const { root, preview, controller } = fixture();
+    const descriptor = Object.getOwnPropertyDescriptor(document, 'fullscreenElement');
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+    const requestFullscreen = vi.fn(() => {
+      fullscreenElement = root;
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+    const exitFullscreen = vi.fn(() => {
+      fullscreenElement = null;
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+    Object.defineProperty(root, 'requestFullscreen', { configurable: true, value: requestFullscreen });
+    Object.defineProperty(document, 'exitFullscreen', { configurable: true, value: exitFullscreen });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    root.querySelector<HTMLButtonElement>('[aria-label="Enter full screen"]')!.click();
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(root.classList.contains('drawio-interactive-fullscreen')).toBe(true);
+    expect(root.querySelector<HTMLButtonElement>('[aria-label="Enter full screen"]')!.hidden).toBe(true);
+    const close = root.querySelector<HTMLButtonElement>('[aria-label="Exit full screen"]')!;
+    expect(close.hidden).toBe(false);
+
+    close.click();
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(root.classList.contains('drawio-interactive-fullscreen')).toBe(false);
+    expect(root.querySelector<HTMLButtonElement>('[aria-label="Enter full screen"]')!.hidden).toBe(false);
+
+    root.querySelector<HTMLButtonElement>('[aria-label="Enter full screen"]')!.click();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(exitFullscreen).toHaveBeenCalledTimes(2);
+    controller.dispose();
+    if (descriptor) Object.defineProperty(document, 'fullscreenElement', descriptor);
+    else delete (document as unknown as { fullscreenElement?: Element | null }).fullscreenElement;
   });
 
   it('creates a full-width viewport using the diagram aspect ratio', () => {

--- a/tests/interactiveViewer.dom.test.ts
+++ b/tests/interactiveViewer.dom.test.ts
@@ -198,8 +198,50 @@ describe('InteractiveViewerController walking skeleton', () => {
     root.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
 
     expect(onEdit).toHaveBeenCalledTimes(1);
-    expect(controller.isActive).toBe(true);
+    expect(controller.isActive).toBe(false);
     controller.dispose();
+  });
+
+  it('exits fullscreen before running Edit', async () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const descriptor = Object.getOwnPropertyDescriptor(document, 'fullscreenElement');
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+    const requestFullscreen = vi.fn(() => {
+      fullscreenElement = root;
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+    const exitFullscreen = vi.fn(() => {
+      fullscreenElement = null;
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+    Object.defineProperty(root, 'requestFullscreen', { configurable: true, value: requestFullscreen });
+    Object.defineProperty(document, 'exitFullscreen', { configurable: true, value: exitFullscreen });
+    const onEdit = vi.fn();
+    const controller = new InteractiveViewerController(root, preview, { onEdit });
+    controller.bindSvg(svg);
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    root.querySelector<HTMLButtonElement>('[aria-label="Enter full screen"]')!.click();
+
+    root.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(controller.isActive).toBe(false);
+    controller.dispose();
+    if (descriptor) Object.defineProperty(document, 'fullscreenElement', descriptor);
+    else delete (document as unknown as { fullscreenElement?: Element | null }).fullscreenElement;
   });
 
   it('enters and exits fullscreen through the preview document', () => {
@@ -335,6 +377,64 @@ describe('InteractiveViewerController walking skeleton', () => {
     const { preview, controller } = fixture();
     controller.applyPersistedHeight(560);
     expect(preview.style.height).toBe('560px');
+    controller.dispose();
+  });
+
+  it('does not apply persisted height while Interactive Viewer is disabled', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const controller = new InteractiveViewerController(root, preview, { isEnabled: () => false });
+    controller.bindSvg(svg);
+    controller.applyPersistedHeight(560);
+    expect(preview.style.height).toBe('');
+    expect(preview.classList.contains('drawio-interactive-viewport')).toBe(false);
+    controller.dispose();
+  });
+
+  it('keeps the current zoom when the persisted height is unchanged', () => {
+    const { root, preview, svg, controller } = fixture();
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
+    frames.shift()!(0);
+    const zoomed = svg.getAttribute('viewBox');
+    const height = parseFloat(preview.style.height);
+
+    controller.applyPersistedHeight(height);
+
+    expect(frames).toHaveLength(0);
+    expect(svg.getAttribute('viewBox')).toBe(zoomed);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('finishes and commits resize when the pointer gesture is cancelled', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const onHeightCommit = vi.fn();
+    const controller = new InteractiveViewerController(root, preview, { onHeightCommit });
+    controller.bindSvg(svg);
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true, clientY: 420 }));
+    const committedHeight = preview.style.height;
+
+    expect(onHeightCommit).toHaveBeenCalledTimes(1);
+    expect(root.classList.contains('drawio-interactive-resizing')).toBe(false);
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 520 }));
+    expect(preview.style.height).toBe(committedHeight);
     controller.dispose();
   });
 

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -65,9 +65,15 @@ export class PluginSettingTab {
   }
 }
 
-class DropdownComponent {
-  addOption(_value: string, _label: string): this { return this; }
-  setValue(_value: string): this { return this; }
+export class DropdownComponent {
+  selectEl = document.createElement('select');
+  constructor(containerEl?: HTMLElement) { containerEl?.appendChild(this.selectEl); }
+  addOption(value: string, label: string): this {
+    this.selectEl.appendChild(new Option(label, value));
+    return this;
+  }
+  setValue(value: string): this { this.selectEl.value = value; return this; }
+  setDisabled(disabled: boolean): this { this.selectEl.disabled = disabled; return this; }
   onChange(_cb: (value: string) => void): this { return this; }
 }
 
@@ -112,7 +118,11 @@ export class Setting {
   }
   setName(name: string): this { this.nameEl.textContent = name; return this; }
   setDesc(desc: string): this { this.descEl.textContent = desc; return this; }
-  addDropdown(cb: (d: DropdownComponent) => unknown): this { cb(new DropdownComponent()); return this; }
+  addDropdown(cb: (d: DropdownComponent) => unknown): this {
+    const dropdown = new DropdownComponent(this.settingEl);
+    cb(dropdown);
+    return this;
+  }
   addToggle(cb: (t: ToggleComponent) => unknown): this { cb(new ToggleComponent()); return this; }
   addText(cb: (t: TextComponent) => unknown): this { cb(new TextComponent()); return this; }
   addButton(cb: (b: ButtonComponent) => unknown): this {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -38,6 +38,7 @@ describe('DEFAULT_SETTINGS', () => {
   it('defaults to the editable file view with the built-in editor click action', () => {
     expect(DEFAULT_SETTINGS.readonlyFileView).toBe(false);
     expect(DEFAULT_SETTINGS.previewClickAction).toBe('editor');
+    expect(DEFAULT_SETTINGS.editButtonAction).toBe('editor');
   });
 
   it('exposes exactly the documented settings keys (guards accidental shape drift)', () => {
@@ -45,6 +46,7 @@ describe('DEFAULT_SETTINGS', () => {
       [
         'customDrawioUrl',
         'drawioMode',
+        'editButtonAction',
         'followObsidianTheme',
         'newDiagramFolder',
         'newDiagramFormat',

--- a/tests/settingsTab.test.ts
+++ b/tests/settingsTab.test.ts
@@ -38,6 +38,16 @@ describe('DrawioSettingTab', () => {
     expect(names).toContain('New diagram location');
     expect(names).toContain('Open diagram files read-only');
     expect(names).toContain('Preview click action');
+    expect(names).not.toContain('Edit button action');
+  });
+
+  it('shows Edit button action only when Interactive viewer is selected', () => {
+    Platform.isDesktopApp = true;
+    const plugin = fakePlugin();
+    plugin.settings.previewClickAction = 'interactive';
+    const tab = new DrawioSettingTab({} as never, plugin);
+    tab.display();
+    expect(rowNames(tab.containerEl)).toContain('Edit button action');
   });
 
   it('hides the editor-only rows on mobile, keeps preview/theme rows', () => {
@@ -53,6 +63,7 @@ describe('DrawioSettingTab', () => {
     expect(names).not.toContain('New diagram folder');
     expect(names).not.toContain('Open diagram files read-only');
     expect(names).not.toContain('Preview click action');
+    expect(names).not.toContain('Edit button action');
     expect(names).toContain('Preview alignment');
     expect(names).toContain('Follow Obsidian theme');
   });

--- a/tests/settingsTab.test.ts
+++ b/tests/settingsTab.test.ts
@@ -47,7 +47,22 @@ describe('DrawioSettingTab', () => {
     plugin.settings.previewClickAction = 'interactive';
     const tab = new DrawioSettingTab({} as never, plugin);
     tab.display();
-    expect(rowNames(tab.containerEl)).toContain('Edit button action');
+    const names = rowNames(tab.containerEl);
+    expect(names).toContain('Edit button action');
+    expect(names).not.toContain('File diagrams');
+    expect(names).not.toContain('Inline code blocks');
+    const group = tab.containerEl.querySelector<HTMLElement>('.drawio-edit-action-settings')!;
+    const rows = Array.from(group.querySelectorAll<HTMLElement>('.drawio-edit-action-row'));
+    expect(rows.map((row) =>
+      row.querySelector('.drawio-edit-action-label')?.textContent,
+    )).toEqual(['File diagrams', 'Inline code blocks']);
+    const fileRow = rows[0]!;
+    const inlineRow = rows[1]!;
+    expect(fileRow.querySelector<HTMLSelectElement>('select')!.disabled).toBe(false);
+    expect(fileRow.querySelectorAll('option')).toHaveLength(2);
+    expect(inlineRow.querySelector<HTMLSelectElement>('select')!.disabled).toBe(true);
+    expect(inlineRow.querySelector<HTMLSelectElement>('select')!.value).toBe('editor');
+    expect(inlineRow.querySelectorAll('option')).toHaveLength(1);
   });
 
   it('hides the editor-only rows on mobile, keeps preview/theme rows', () => {

--- a/tests/viewportHeight.test.ts
+++ b/tests/viewportHeight.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseViewportHeightComment,
+  upsertViewportHeightComment,
+} from '../src/preview/viewportHeight';
+
+describe('viewport height Markdown metadata', () => {
+  it('parses only the dedicated integer-pixel comment', () => {
+    expect(parseViewportHeightComment('<!-- drawio-viewer: height=480 -->')).toBe(480);
+    expect(parseViewportHeightComment('  <!-- drawio-viewer: height=80 -->')).toBe(80);
+    expect(parseViewportHeightComment('<!-- drawio-viewer: height=50% -->')).toBeNull();
+    expect(parseViewportHeightComment('<!-- other: height=480 -->')).toBeNull();
+  });
+
+  it('inserts a comment immediately before the selected code block', () => {
+    const doc = ['before', '```drawio', '<mxfile/>', '```', 'after'].join('\n');
+    expect(upsertViewportHeightComment(doc, 1, 480)).toBe(
+      ['before', '<!-- drawio-viewer: height=480 -->', '```drawio', '<mxfile/>', '```', 'after'].join('\n'),
+    );
+  });
+
+  it('updates the existing dedicated comment without touching neighboring text', () => {
+    const doc = [
+      '<!-- drawio-viewer: height=320 -->',
+      '```drawio',
+      '<mxfile/>',
+      '```',
+      '<!-- drawio-viewer: height=900 -->',
+      '```drawio',
+      '<mxfile/>',
+      '```',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 5, 640)).toBe([
+      '<!-- drawio-viewer: height=320 -->',
+      '```drawio',
+      '<mxfile/>',
+      '```',
+      '<!-- drawio-viewer: height=640 -->',
+      '```drawio',
+      '<mxfile/>',
+      '```',
+    ].join('\n'));
+  });
+});


### PR DESCRIPTION
Closes #18 

## Summary

This pull request adds two related preview features:

- an Interactive Viewer with zoom, pan, Fit, Edit, and fullscreen controls;
- persistent resizable height for inline Draw.io code blocks and file-backed embeds.

Existing preview click actions remain unchanged unless Interactive Viewer is selected.

## Interactive Viewer

The new viewer works on desktop for:

- inline `drawio` code blocks;
- file-backed embeds in Live Preview and Reading view;
- read-only `.drawio` file views.

The viewer is inactive by default and does not intercept document scrolling. Clicking the preview activates it; clicking outside or pressing `Escape` deactivates it.

The active toolbar provides:

- zoom in and zoom out;
- Fit;
- Edit;
- Full screen;
- a close button while in fullscreen.

Wheel and trackpad zoom use a small step and keep the point under the cursor anchored. Pointer dragging pans the zoomed diagram within its bounds.

Zoom and pan update the existing sanitized SVG instead of regenerating it. Their state is temporary and resets after page changes, rerenders, or reopening the note.

## Resizable preview height

Inline code blocks and file-backed embeds receive a bottom resize handle.

The selected height:

- belongs to the individual Markdown insertion;
- is shared by every page inside that insertion;
- can differ between repeated embeds of the same Draw.io file;
- is synchronized between Live Preview and Reading view;
- persists after reopening the note.

The height is stored immediately before the insertion:

```markdown
<!-- drawio-viewer: height=480 -->
![[diagram.drawio]]
```

Saved height is currently applied only when Interactive Viewer is selected, preventing changes to existing preview modes.

Read-only `.drawio` file views have no Markdown insertion, so their resized height is session-only.

## Edit routing

When Interactive Viewer is enabled, the settings display an additional Edit button action group:

- file-backed diagrams can open in the built-in editor or system default application;
- inline code blocks always use the built-in editor because they have no standalone file.

Opening the editor deactivates the viewer and exits fullscreen first when necessary.

## Compatibility

- Existing preview click actions retain their previous behavior.
- Static SVG sanitization remains unchanged.
- Multi-page controls continue to work.
- Multiple embeds maintain independent state.
- Popout windows use their own document for fullscreen and event handling.
- Mobile keeps the existing static preview behavior.

## Validation

Automated checks:

- `npm test` — 46 test files, 351 tests passed
- `npm run build` — passed
- `git diff --check` — passed

Manual desktop checks:

- inline code blocks;
- Live Preview and Reading view embeds;
- repeated and multi-page embeds;
- read-only `.drawio` file view;
- zoom, pan, Fit, resize, Edit, and fullscreen;
- split views and popout windows;
- persisted height after reopening the note.

**Manual testing on mobile devices has not been performed.**