### PR TITLE
feat(installer): verify draw.war against a pinned SHA-256

### DIFF
--- a/scripts/fetch-drawio.mjs
+++ b/scripts/fetch-drawio.mjs
@@ -1,12 +1,17 @@
 // Downloads a pinned drawio webapp (draw.war = ZIP) and extracts static files to webapp/.
 import { copyFileSync, createWriteStream, existsSync, mkdirSync, rmSync } from 'node:fs';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { execFileSync, spawnSync } from 'node:child_process';
 
 const DRAWIO_VERSION = 'v30.3.11';
+// SHA-256 of the pinned draw.war — MUST match DRAWIO_WAR_SHA256 in
+// src/constants.ts (guarded by tests/drawioVersionSync.test.ts), so the
+// build-time fetch and the runtime installer accept the exact same bytes.
+const WAR_SHA256 = '8fd2efb34c2a4792ba24c2583500d6e9e0b893b02f288f4ab9da545a7aaeb076';
 const WAR_URL = `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`;
 const OUT_DIR = join(process.cwd(), 'webapp');
 
@@ -15,6 +20,26 @@ async function download(url, dest) {
   if (!res.ok) throw new Error(`Download failed: ${res.status} ${url}`);
   if (!res.body) throw new Error(`Response body is null for ${url}`);
   await pipeline(res.body, createWriteStream(dest));
+}
+
+/**
+ * Abort unless the downloaded archive hashes to the pinned SHA-256. Runs before
+ * anything is extracted, so a bad download can never reach webapp/ or the
+ * vendored viewer.min.txt.
+ */
+async function verifyWarChecksum(file, expected) {
+  const actual = createHash('sha256').update(await readFile(file)).digest('hex');
+  if (actual !== expected) {
+    throw new Error(
+      `BLOCKED: checksum mismatch for ${WAR_URL}\n` +
+      `  expected sha256 ${expected}\n` +
+      `  actual   sha256 ${actual}\n` +
+      'The download was corrupted, or the pinned archive changed upstream. ' +
+      'Nothing was extracted. Re-run `npm run fetch-drawio`; if it keeps failing, ' +
+      'update WAR_SHA256 here and DRAWIO_WAR_SHA256 in src/constants.ts together, ' +
+      'and only after verifying the new archive.'
+    );
+  }
 }
 
 /**
@@ -58,14 +83,19 @@ function extractWithPython(pythonCmd, archive, destDir) {
 }
 
 async function main() {
-  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
-  mkdirSync(OUT_DIR, { recursive: true });
-
   const tmp = await mkdtemp(join(tmpdir(), 'drawio-'));
   try {
     const war = join(tmp, 'draw.war');
     console.log(`Downloading ${WAR_URL} ...`);
     await download(WAR_URL, war);
+
+    console.log('Verifying checksum ...');
+    await verifyWarChecksum(war, WAR_SHA256);
+
+    // Only now is the previous webapp/ cleared: a failed download or a checksum
+    // mismatch above leaves whatever was already extracted fully intact.
+    if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+    mkdirSync(OUT_DIR, { recursive: true });
 
     // draw.war is a ZIP. Extract everything, then drop the server-only WEB-INF/META-INF.
     console.log('Extracting ...');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,19 @@ export const DRAWIO_VERSION = 'v30.3.11';
 export const DRAWIO_WAR_URL =
   `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`;
 
+/** SHA-256 of the pinned draw.war. Checked against the downloaded bytes before
+ * anything is extracted or installed — by the runtime installer
+ * (src/desktop/webappInstaller.ts) and by scripts/fetch-drawio.mjs, which pins
+ * the same literal (guarded by tests/drawioVersionSync.test.ts).
+ *
+ * Upstream publishes no checksum file: this digest was computed from the
+ * archive at DRAWIO_WAR_URL and cross-checked against the digest GitHub reports
+ * for that release asset. Bump it in both places whenever DRAWIO_VERSION moves,
+ * and only after verifying the new archive — a mismatch is meant to fail the
+ * build and the install loudly. */
+export const DRAWIO_WAR_SHA256 =
+  '8fd2efb34c2a4792ba24c2583500d6e9e0b893b02f288f4ab9da545a7aaeb076';
+
 /** Default empty mxfile diagram. */
 export const EMPTY_DIAGRAM =
   '<mxfile><diagram id="0" name="Page-1"><mxGraphModel dx="800" dy="600" grid="1" ' +

--- a/src/desktop/webappInstaller.ts
+++ b/src/desktop/webappInstaller.ts
@@ -1,10 +1,11 @@
 import { get as httpsGet } from 'node:https';
+import { createHash } from 'node:crypto';
 import {
   existsSync, mkdirSync, renameSync, rmSync, writeFileSync,
 } from 'node:fs';
 import { dirname, join, normalize, sep } from 'node:path';
 import { unzipSync } from 'fflate';
-import { DRAWIO_VERSION, DRAWIO_WAR_URL } from '../constants';
+import { DRAWIO_VERSION, DRAWIO_WAR_SHA256, DRAWIO_WAR_URL } from '../constants';
 import type { InstallProgress } from '../model/installStatus';
 
 /** Top-level directories in draw.war that are server-only and never served
@@ -12,9 +13,10 @@ import type { InstallProgress } from '../model/installStatus';
 const SKIP_PREFIXES = ['WEB-INF/', 'META-INF/'];
 
 /**
- * Download the pinned drawio webapp and install it into `<pluginDir>/webapp`.
- * The caller (settings tab) must stop the local server first — on Windows an
- * open file handle inside webapp/ would make the final swap fail.
+ * Download the pinned drawio webapp, verify it against DRAWIO_WAR_SHA256, and
+ * install it into `<pluginDir>/webapp`. The caller (settings tab) must stop the
+ * local server first — on Windows an open file handle inside webapp/ would make
+ * the final swap fail.
  *
  * The whole archive (~53 MB) is buffered in memory: it spares a temp file and
  * its cleanup, and is well within desktop Electron's budget.
@@ -53,11 +55,24 @@ function nextPaint(): Promise<void> {
   return Promise.race([paint, hiddenWindowFallback]);
 }
 
-/** The post-download half, separated for network-free testing: extract into a
- * staging dir, validate, then atomically swap into place. On any failure the
- * staging dir is removed; an existing webapp/ is either left fully in place
- * or fully restored — see `swapWebappIntoPlace`. */
-export function installFromWar(war: Uint8Array, pluginDir: string): void {
+/** The post-download half, separated for network-free testing: verify the
+ * archive's SHA-256, extract into a staging dir, validate, then atomically swap
+ * into place. On any failure the staging dir is removed; an existing webapp/ is
+ * either left fully in place or fully restored — see `swapWebappIntoPlace`.
+ *
+ * `expectedSha256` defaults to the pinned digest and is only ever passed by
+ * tests, which build small synthetic archives. Callers in production must not
+ * pass it — `installWebapp` deliberately keeps it out of its own signature, so
+ * the shipped path can only ever check against the pin. */
+export function installFromWar(
+  war: Uint8Array,
+  pluginDir: string,
+  expectedSha256: string = DRAWIO_WAR_SHA256,
+): void {
+  // Integrity gate first, ahead of every filesystem write below: an archive
+  // that fails it leaves the vault byte-for-byte untouched — no staging dir,
+  // no half-replaced webapp/.
+  verifyWarChecksum(war, expectedSha256);
   const staging = join(pluginDir, 'webapp.installing');
   rmSync(staging, { recursive: true, force: true });
   try {
@@ -76,6 +91,31 @@ export function installFromWar(war: Uint8Array, pluginDir: string): void {
     // away, force:true makes this a harmless no-op).
     rmSync(staging, { recursive: true, force: true });
     throw e;
+  }
+}
+
+/**
+ * Throw unless `war` hashes to `expected` (lowercase hex SHA-256).
+ *
+ * HTTPS and a version-pinned URL already make a substituted archive unlikely;
+ * this turns "unlikely" into "detected", and also catches a body that arrived
+ * intact-looking but corrupt (Content-Length only proves the byte count).
+ *
+ * Plain `!==` rather than a constant-time compare on purpose: the digest is a
+ * public constant compiled into the plugin, so there is no secret for a timing
+ * side channel to leak.
+ *
+ * Exported for tests.
+ */
+export function verifyWarChecksum(war: Uint8Array, expected: string = DRAWIO_WAR_SHA256): void {
+  const actual = createHash('sha256').update(war).digest('hex');
+  if (actual !== expected) {
+    throw new Error(
+      'The downloaded drawio archive does not match the checksum this plugin ' +
+      'version expects, so nothing was installed. The download may have been ' +
+      'corrupted in transit, or the archive published upstream may have changed. ' +
+      `Check your connection and try again. Expected SHA-256 ${expected}, got ${actual}.`,
+    );
   }
 }
 

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -6,6 +6,8 @@ import {
   DRAWIO_VIEW_TYPE,
   DRAWIO_FILE_EXT,
   DRAWIO_CODE_BLOCK_LANG,
+  DRAWIO_WAR_SHA256,
+  DRAWIO_WAR_URL,
 } from '../src/constants';
 import { isValidDrawioXml, getDiagramPages } from '../src/model/xmlUtils';
 
@@ -57,6 +59,13 @@ describe('constant invariants', () => {
 
   it('ONLINE_DRAWIO_URL points at the hosted embed app over https', () => {
     expect(ONLINE_DRAWIO_URL).toBe('https://embed.diagrams.net/');
+  });
+
+  it('pins the webapp archive to https and a full lowercase SHA-256', () => {
+    // A stray uppercase digit or a truncated paste would make every install
+    // fail the checksum gate; comparison is plain hex equality.
+    expect(DRAWIO_WAR_URL.startsWith('https://')).toBe(true);
+    expect(DRAWIO_WAR_SHA256).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it('exposes the stable view type / extension / block-language identifiers', () => {

--- a/tests/drawioVersionSync.test.ts
+++ b/tests/drawioVersionSync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { DRAWIO_VERSION, DRAWIO_WAR_URL } from '../src/constants';
+import { DRAWIO_VERSION, DRAWIO_WAR_SHA256, DRAWIO_WAR_URL } from '../src/constants';
 
 // The runtime installer (src/desktop/webappInstaller.ts) and the build-time
 // fetch script must install the exact same drawio version, or the bundled
@@ -16,5 +16,22 @@ describe('drawio version pinning', () => {
     expect(DRAWIO_WAR_URL).toBe(
       `https://github.com/jgraph/drawio/releases/download/${DRAWIO_VERSION}/draw.war`,
     );
+  });
+
+  // Both download paths must accept the exact same bytes; the script can't
+  // import the TS constant, so the two literals are pinned to each other here.
+  it('matches the draw.war SHA-256 pinned in scripts/fetch-drawio.mjs', () => {
+    const script = readFileSync('scripts/fetch-drawio.mjs', 'utf8');
+    const m = script.match(/WAR_SHA256 = '([^']+)'/);
+    expect(m?.[1]).toBe(DRAWIO_WAR_SHA256);
+  });
+
+  it('verifies the archive in scripts/fetch-drawio.mjs before extracting it', () => {
+    const script = readFileSync('scripts/fetch-drawio.mjs', 'utf8');
+    const verifiedAt = script.indexOf('await verifyWarChecksum(');
+    const extractedAt = script.indexOf("console.log('Extracting ...')");
+    expect(verifiedAt).toBeGreaterThan(-1);
+    expect(extractedAt).toBeGreaterThan(-1);
+    expect(verifiedAt).toBeLessThan(extractedAt);
   });
 });

--- a/tests/drawioVersionSync.test.ts
+++ b/tests/drawioVersionSync.test.ts
@@ -26,12 +26,18 @@ describe('drawio version pinning', () => {
     expect(m?.[1]).toBe(DRAWIO_WAR_SHA256);
   });
 
-  it('verifies the archive in scripts/fetch-drawio.mjs before extracting it', () => {
+  // Ordering guard for the build-time path: the checksum must be checked before
+  // the script touches webapp/ or unpacks anything. Anchored on call-site tokens
+  // (not log text) — if any of them is renamed, update this list with it.
+  it('verifies the archive in scripts/fetch-drawio.mjs before touching webapp/', () => {
     const script = readFileSync('scripts/fetch-drawio.mjs', 'utf8');
     const verifiedAt = script.indexOf('await verifyWarChecksum(');
-    const extractedAt = script.indexOf("console.log('Extracting ...')");
+    const clearedAt = script.indexOf('rmSync(OUT_DIR');
+    const extractedAt = script.indexOf('extractWithUnzip(war,');
     expect(verifiedAt).toBeGreaterThan(-1);
+    expect(clearedAt).toBeGreaterThan(-1);
     expect(extractedAt).toBeGreaterThan(-1);
+    expect(verifiedAt).toBeLessThan(clearedAt);
     expect(verifiedAt).toBeLessThan(extractedAt);
   });
 });

--- a/tests/webappInstaller.test.ts
+++ b/tests/webappInstaller.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { zipSync, strToU8 } from 'fflate';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { installFromWar, swapWebappIntoPlace } from '../src/desktop/webappInstaller';
-import { DRAWIO_VERSION } from '../src/constants';
+import {
+  installFromWar, swapWebappIntoPlace, verifyWarChecksum,
+} from '../src/desktop/webappInstaller';
+import { DRAWIO_VERSION, DRAWIO_WAR_SHA256 } from '../src/constants';
 
 function makeWar(entries: Record<string, Uint8Array> = {}): Uint8Array {
   return zipSync({
@@ -16,13 +19,19 @@ function makeWar(entries: Record<string, Uint8Array> = {}): Uint8Array {
   });
 }
 
+/** These synthetic archives are not the pinned draw.war, so every install call
+ * below must state the digest it expects — exactly the checksum gate under
+ * test. `installFromWar(war, dir)` without it uses the real pin and fails. */
+const sha256 = (data: Uint8Array): string => createHash('sha256').update(data).digest('hex');
+
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'drawio-install-')); });
 afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
 describe('installFromWar', () => {
   it('extracts the webapp, skipping WEB-INF/META-INF, and writes DRAWIO_VERSION', () => {
-    installFromWar(makeWar(), dir);
+    const war = makeWar();
+    installFromWar(war, dir, sha256(war));
     expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('<html>drawio</html>');
     expect(existsSync(join(dir, 'webapp', 'js', 'viewer.min.js'))).toBe(true);
     expect(existsSync(join(dir, 'webapp', 'WEB-INF'))).toBe(false);
@@ -34,7 +43,8 @@ describe('installFromWar', () => {
   it('replaces an existing webapp atomically', () => {
     mkdirSync(join(dir, 'webapp'), { recursive: true });
     writeFileSync(join(dir, 'webapp', 'stale.txt'), 'old');
-    installFromWar(makeWar(), dir);
+    const war = makeWar();
+    installFromWar(war, dir, sha256(war));
     expect(existsSync(join(dir, 'webapp', 'stale.txt'))).toBe(false);
     expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
     expect(existsSync(join(dir, 'webapp.old'))).toBe(false);
@@ -43,7 +53,8 @@ describe('installFromWar', () => {
   it('cleans leftover webapp.installing from a previously interrupted run', () => {
     mkdirSync(join(dir, 'webapp.installing'), { recursive: true });
     writeFileSync(join(dir, 'webapp.installing', 'junk.txt'), 'junk');
-    installFromWar(makeWar(), dir);
+    const war = makeWar();
+    installFromWar(war, dir, sha256(war));
     expect(existsSync(join(dir, 'webapp', 'junk.txt'))).toBe(false);
     expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
   });
@@ -52,7 +63,7 @@ describe('installFromWar', () => {
     mkdirSync(join(dir, 'webapp'), { recursive: true });
     writeFileSync(join(dir, 'webapp', 'index.html'), 'previous install');
     const bad = zipSync({ 'js/viewer.min.js': strToU8('// viewer only') });
-    expect(() => installFromWar(bad, dir)).toThrow(/index\.html/);
+    expect(() => installFromWar(bad, dir, sha256(bad))).toThrow(/index\.html/);
     // Old install untouched, staging cleaned up.
     expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('previous install');
     expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
@@ -63,9 +74,64 @@ describe('installFromWar', () => {
     // guard in the implementation and adapt this test to call the exported
     // path check directly instead of deleting the test.
     const evil = makeWar({ '../evil.txt': strToU8('escape') });
-    expect(() => installFromWar(evil, dir)).toThrow(/[Uu]nsafe zip entry/);
+    expect(() => installFromWar(evil, dir, sha256(evil))).toThrow(/[Uu]nsafe zip entry/);
     expect(existsSync(join(dir, 'evil.txt'))).toBe(false);
     expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+  });
+});
+
+describe('installFromWar checksum gate', () => {
+  it('installs an archive whose digest matches the expected one', () => {
+    const war = makeWar();
+    expect(() => installFromWar(war, dir, sha256(war))).not.toThrow();
+    expect(existsSync(join(dir, 'webapp', 'index.html'))).toBe(true);
+  });
+
+  it('aborts on a digest mismatch without touching the filesystem', () => {
+    mkdirSync(join(dir, 'webapp'), { recursive: true });
+    writeFileSync(join(dir, 'webapp', 'index.html'), 'previous install');
+    expect(() => installFromWar(makeWar(), dir, 'f'.repeat(64)))
+      .toThrow(/does not match the checksum/);
+    // The gate runs before every write: the old install is byte-identical and
+    // no staging dir was ever created.
+    expect(readFileSync(join(dir, 'webapp', 'index.html'), 'utf8')).toBe('previous install');
+    expect(existsSync(join(dir, 'webapp.installing'))).toBe(false);
+    expect(existsSync(join(dir, 'webapp.old'))).toBe(false);
+  });
+
+  it('rejects a tampered archive that would otherwise install cleanly', () => {
+    // Same structure, different bytes: only the digest can tell them apart.
+    const tampered = makeWar({ 'js/app.min.js': strToU8('/* injected */') });
+    expect(() => installFromWar(tampered, dir, sha256(makeWar())))
+      .toThrow(/does not match the checksum/);
+    expect(existsSync(join(dir, 'webapp'))).toBe(false);
+  });
+
+  it('defaults to the pinned DRAWIO_WAR_SHA256 when no digest is passed', () => {
+    // Guards the shipped path: installWebapp() never passes a digest, so this
+    // default is what a real install is checked against.
+    expect(() => installFromWar(makeWar(), dir)).toThrow(DRAWIO_WAR_SHA256);
+    expect(existsSync(join(dir, 'webapp'))).toBe(false);
+  });
+});
+
+describe('verifyWarChecksum', () => {
+  const bytes = strToU8('drawio archive bytes');
+  const digest = sha256(bytes);
+
+  it('accepts bytes hashing to the expected digest', () => {
+    expect(() => verifyWarChecksum(bytes, digest)).not.toThrow();
+  });
+
+  it('rejects bytes hashing to anything else, naming both digests', () => {
+    const other = sha256(strToU8('other bytes'));
+    expect(() => verifyWarChecksum(bytes, other)).toThrow(other);
+    expect(() => verifyWarChecksum(bytes, other)).toThrow(digest);
+  });
+
+  it('rejects a truncated archive (Content-Length alone would not)', () => {
+    expect(() => verifyWarChecksum(bytes.slice(0, -1), digest))
+      .toThrow(/does not match the checksum/);
   });
 });
 


### PR DESCRIPTION
Closes #17

Both paths that download the pinned `draw.war` now verify the complete archive against a pinned SHA-256 before anything is extracted or installed.

## Changes

- **`src/constants.ts`** — new `DRAWIO_WAR_SHA256`, stored beside `DRAWIO_VERSION` and `DRAWIO_WAR_URL`. `scripts/fetch-drawio.mjs` pins the same literal (a `.mjs` script cannot import the TS constant); `tests/drawioVersionSync.test.ts` keeps the two in lockstep, the same single-source-of-truth pattern already used for the version.
- **`src/desktop/webappInstaller.ts`** — `verifyWarChecksum()` runs as the *first* statement of `installFromWar()`, ahead of every filesystem write. A mismatching archive therefore leaves the vault byte-for-byte untouched: no `webapp.installing/`, no half-replaced `webapp/`. The rename-aside swap and its rollback are unchanged. The expected digest is a default parameter that only tests pass; `installWebapp()` deliberately keeps it out of its own signature, so the shipped path can only ever check against the pin. Hashing happens after the existing `nextPaint()`, so the ~200 ms of main-thread work inherits the committed "Extracting…" frame rather than freezing on a stale download percentage — no new progress phase was needed.
- **`scripts/fetch-drawio.mjs`** — verifies after download and before extraction, and now clears the existing `webapp/` only once the archive is known good (previously a failed download wiped it first).

The user-facing error names both digests and gives the two plausible causes:

> The downloaded drawio archive does not match the checksum this plugin version expects, so nothing was installed. The download may have been corrupted in transit, or the archive published upstream may have changed. Check your connection and try again. Expected SHA-256 …, got ….

## Digest provenance

`8fd2efb34c2a4792ba24c2583500d6e9e0b893b02f288f4ab9da545a7aaeb076` (52,634,062 bytes).

jgraph publishes no checksum file for the release, so the value was computed locally with `sha256sum` from the archive at the pinned URL and cross-checked against the `digest` GitHub's release-asset API reports for `v30.3.11`'s `draw.war` — the two agree, as do the byte counts.

Intended consequence worth stating explicitly: if the bytes behind that release URL ever change, `npm run fetch-drawio` fails CI loudly instead of silently building against different code. That is the same philosophy as `sanitizeDrawioViewerPlugin`'s "assert exactly one match" check, and a drawio version bump now means updating the digest in both places alongside `DRAWIO_VERSION`.

## Tests

`npm test` — 312 passed / 42 files. `npm run build` — clean (`node:crypto` bundles to `require("node:crypto")`; the native-import guard plugin is satisfied).

New coverage:

- `installFromWar` with a matching digest installs; with a mismatching digest it throws and leaves an existing `webapp/` byte-identical with no staging dir created.
- A tampered archive with identical structure but different bytes is rejected — only the digest can tell it apart from a good one.
- Calling `installFromWar` with no digest argument (the production shape) rejects a synthetic archive and names `DRAWIO_WAR_SHA256`, proving the shipped default is the pin and is enforced.
- `verifyWarChecksum` unit tests for match, mismatch, and a truncated archive (which `Content-Length` alone would not catch).
- `DRAWIO_WAR_SHA256` is asserted to be full lowercase hex, and to equal the literal in `scripts/fetch-drawio.mjs`; a further assertion pins the script's verify call ahead of its extraction step.

The build script's own two branches were additionally exercised by hand against a local fixture archive (wrong digest: exit 1, pre-existing `webapp/` untouched; correct digest: extracts normally), and CI's real `npm run fetch-drawio` covers the happy path against the real archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
