### PR TITLE
docs: add issue templates and a README troubleshooting section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. A few quick details make bugs
+        far faster to fix. Before filing, please skim the
+        [Troubleshooting section of the README](https://github.com/doge-liang/obsidian-drawio#troubleshooting) —
+        it covers the most common issues (the offline editor not being installed,
+        a blank editor, stale dual-format images, and mobile editing).
+  - type: checkboxes
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and this has not been reported yet.
+          required: true
+        - label: I read the README Troubleshooting section.
+          required: true
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: "Settings → Community plugins → Drawio, or the top of the plugin's settings tab."
+      placeholder: e.g. 0.5.3
+    validations:
+      required: true
+  - type: input
+    id: obsidian-version
+    attributes:
+      label: Obsidian version
+      description: "Help → About → Current version (also note if you are on an Insider/Catalyst build)."
+      placeholder: e.g. 1.8.10
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows (desktop)
+        - macOS (desktop)
+        - Linux (desktop)
+        - iOS / iPadOS (mobile)
+        - Android (mobile)
+    validations:
+      required: true
+  - type: dropdown
+    id: editor-source
+    attributes:
+      label: Editor source
+      description: "Settings → Drawio → Editor source. (Previews work the same on all three; editing differs.)"
+      options:
+        - Offline (bundled webapp)
+        - Online (diagrams.net)
+        - Custom URL
+        - "Not sure / not relevant (preview-only issue)"
+    validations:
+      required: true
+  - type: dropdown
+    id: offline-installed
+    attributes:
+      label: Is the offline editor installed?
+      description: "Settings → Drawio — the Offline row shows Install / Update when it is missing or out of date."
+      options:
+        - "Yes, installed and up to date"
+        - "No / it shows an Install button"
+        - "It shows an Update button"
+        - "Not applicable (Online or Custom)"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: |
+        1. Open a note with a ![[diagram.drawio]] embed
+        2. Click the preview
+        3. Expected the editor to open; instead …
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console output (optional)
+      description: >-
+        On desktop, open the developer console (Ctrl/Cmd+Shift+I → Console) and paste
+        any red errors from the moment the problem occurs. This is the single most
+        useful thing for diagnosing editor/preview failures.
+      render: text
+  - type: checkboxes
+    attributes:
+      label: Follow-up
+      options:
+        - label: I am willing to test a fix in a pre-release build.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting (read first)
+    url: https://github.com/doge-liang/obsidian-drawio#troubleshooting
+    about: Most common problems — offline editor not installed, blank editor, stale dual-format images, mobile editing — are answered here.
+  - name: Questions & discussion
+    url: https://forum.obsidian.md/c/share-showcase/9
+    about: For usage questions and general discussion, please use the Obsidian community forum rather than the issue tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest a new capability or an improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature ideas are very welcome. Describing the underlying problem — not just
+        the solution you have in mind — helps land something that fits the plugin's
+        offline-first, review-compliant design.
+  - type: checkboxes
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and this has not been requested yet.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and where does the plugin get in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like the plugin to do? UI, command, setting, behavior — whatever you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Other approaches, workarounds you use now, or how other tools handle this.
+  - type: dropdown
+    id: platform-scope
+    attributes:
+      label: Where should this apply?
+      options:
+        - Desktop only
+        - Mobile only
+        - Both desktop and mobile
+        - Not sure
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ A store install ships without the offline drawio webapp (it is ~145 MB, beyond s
 
 Building from source also works and produces the same layout: run `npm run fetch-drawio` before `npm run build` and copy the `webapp/` folder alongside `main.js` (see Development below).
 
+## Troubleshooting
+
+**Clicking a diagram does nothing / the editor won't open.** Editing is desktop-only. On mobile you get previews only. On desktop, check **Settings → Drawio → Preview click action** — if it is set to **Do nothing**, previews are intentionally not clickable.
+
+**"The offline editor isn't installed" — or the editor opens blank in Offline mode.** A store install ships without the ~145 MB offline webapp. Open **Settings → Drawio**, keep **Editor source → Offline (bundled webapp)**, and click **Install** (a one-time ~53 MB download). Alternatively switch **Editor source** to **Online** to load the editor from diagrams.net. See [Offline editor](#offline-editor-optional) for a fully-offline install without downloading in-app.
+
+**The editor is blank after a plugin update.** A plugin update can bump the bundled drawio version. Open **Settings → Drawio** and click **Update** on the Offline row to bring the installed editor in step; until then it keeps working on the previous version.
+
+**The editor stays blank in a pop-out window.** This should work — if a diagram opened in a pop-out window renders blank, please file a bug with your Obsidian version. As a workaround, edit the diagram in the main window.
+
+**A preview shows "Invalid drawio diagram".** The block or file doesn't contain a valid drawio diagram. For a ` ```drawio ` block, the content must be drawio/mxGraph XML (an `<mxfile>` / `<mxGraphModel>`, or a full diagram exported from draw.io). Pasting AI-generated draw.io XML into the block should just render.
+
+**A `.drawio.svg` / `.drawio.png` image looks stale after I edited the diagram elsewhere.** Dual-format files keep the editable XML inside the image. If the XML is changed without re-exporting (for example by a fallback save), the picture can lag behind the data. Open the file here and save once — the editor re-exports the image to match.
+
+**Nothing renders on mobile, or I can't edit on mobile.** Mobile is preview-only by design (code blocks, embeds, and a read-only view for `.drawio` files, including multi-page navigation). Open the vault on a desktop to edit.
+
+Still stuck? Open the developer console (**Ctrl/Cmd+Shift+I → Console**), reproduce the problem, and include any red errors when you [file an issue](https://github.com/doge-liang/obsidian-drawio/issues/new/choose).
+
 ## Notes & limitations
 
 - **Editing is desktop-only** — it needs the iframe-based drawio editor and, in Offline mode, a local HTTP server. Mobile gets previews (see [Platform support](#platform-support)).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,24 @@
 
 从源码构建同样可行，产物布局相同：先运行 `npm run fetch-drawio` 再 `npm run build`，并将 `webapp/` 文件夹与 `main.js` 一并复制（参见下文的[开发](#开发)章节）。
 
+## 疑难解答
+
+**点击图表没有反应 / 编辑器打不开。** 编辑仅限桌面端，移动端只能预览。在桌面端，请检查 **设置 → Drawio → Preview click action** —— 若设为 **Do nothing**，预览会被有意设为不可点击。
+
+**提示「离线编辑器未安装」，或 Offline 模式下编辑器打开是空白。** 商店安装不含约 145 MB 的离线 webapp。打开 **设置 → Drawio**，保持 **Editor source → Offline (bundled webapp)**，点击 **Install**（一次性约 53 MB 下载）。也可以把 **Editor source** 切到 **Online**，从 diagrams.net 加载编辑器。若想完全离线安装、不在应用内下载，参见[离线编辑器](#离线编辑器可选)。
+
+**插件更新后编辑器变空白。** 插件更新可能提升内置的 drawio 版本。打开 **设置 → Drawio**，在 Offline 行点击 **Update**，让已安装的编辑器与之一致；在此之前它仍以旧版本工作。
+
+**在弹出窗口（pop-out）里编辑器保持空白。** 这本应正常工作 —— 若在弹出窗口中打开的图表渲染为空白，请附上你的 Obsidian 版本提交 bug。临时办法是在主窗口中编辑该图表。
+
+**预览显示「Invalid drawio diagram」。** 该代码块或文件不含有效的 drawio 图表。对于 ` ```drawio ` 代码块，内容必须是 drawio/mxGraph XML（`<mxfile>` / `<mxGraphModel>`，或从 draw.io 导出的完整图表）。把 AI 生成的 draw.io XML 粘进代码块通常即可渲染。
+
+**`.drawio.svg` / `.drawio.png` 图片在别处编辑图表后显得过时。** 双格式文件把可编辑的 XML 存在图片内部。如果 XML 被改动却未重新导出（例如某次回退保存），图片可能落后于数据。在此打开该文件并保存一次 —— 编辑器会重新导出图片以与之匹配。
+
+**移动端什么都渲染不出来，或无法在移动端编辑。** 移动端按设计只做预览（代码块、嵌入，以及 `.drawio` 文件的只读视图，含多页导航）。请在桌面端打开库以进行编辑。
+
+仍未解决？打开开发者控制台（**Ctrl/Cmd+Shift+I → Console**），复现问题，并在[提交 issue](https://github.com/doge-liang/obsidian-drawio/issues/new/choose) 时附上任何红色报错。
+
 ## 注意事项与限制
 
 - **编辑仅限桌面端** —— 它需要基于 iframe 的 drawio 编辑器，且在 Offline 模式下需要本地 HTTP 服务器。移动端可预览（参见[平台支持](#平台支持)）。


### PR DESCRIPTION
Part of the 0.6.0 adoption-funnel work: make the predictable support load self-serve before the community-forum announcement drives traffic here.

- **Issue templates**: a bug-report form (preflight checkboxes, plugin/Obsidian versions, platform, editor source) and a feature-request form; blank issues are disabled in favor of the README Troubleshooting section and the Obsidian forum (`config.yml` contact links).
- **README Troubleshooting** (mirrored in `README.zh-CN.md` per the bilingual rule): covers the offline editor not being installed, a blank editor after an update, pop-out issues, invalid-diagram errors, stale dual-format images, and mobile being preview-only — each entry names the exact setting/button involved. The bug-report form links to this section.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)