### PR TITLE
feat(embed): click-to-edit hotspot for dual-format image embeds

### DIFF
--- a/docs/MANUAL_TESTS.md
+++ b/docs/MANUAL_TESTS.md
@@ -54,3 +54,26 @@ Needs a note embedding a multi-page diagram twice: once bare
 - [ ] A markdown-style embed (`![alt](multi.drawio)`) shows the "markdown-style link" Notice on pin and the note text is untouched.
 - [ ] Clicking the pin never also triggers the embed click action
       (editor/default app).
+
+## Dual-format embed click-to-edit (0.6.0)
+
+Needs a `.drawio.svg` (and a `.drawio.png`) embedded in a note:
+`![[diagram.drawio.svg]]`. Test in **Reading view** (the hotspot is
+Reading-view only by design).
+
+- [ ] The embedded image shows an Edit (pencil) hint on hover, and clicking
+      anywhere on it opens the editor on the embedded diagram (not Obsidian's
+      image lightbox).
+- [ ] Editing and saving updates both the embedded XML and the rendered image.
+- [ ] With **Preview click action → Open in default app**, clicking opens the
+      file in the OS default app instead; with **Do nothing**, the image is not
+      clickable and shows no hint.
+- [ ] With **Preview click action → Interactive viewer**, clicking opens the
+      editor (the interactive viewer only drives `.drawio` SVG previews; the
+      native image has nothing to explore).
+- [ ] A plain (non-drawio) `.svg`/`.png` embed is unaffected — no hint, normal
+      image behavior.
+- [ ] On mobile, the native image is untouched (no hijacked click).
+- [ ] The standalone `.drawio.svg`/`.drawio.png` file tab still edits via the
+      right-click **Edit drawio diagram** menu / command (file-tab hotspot is
+      intentionally not added — Obsidian owns the native image view).

--- a/src/file/EmbedRenderer.ts
+++ b/src/file/EmbedRenderer.ts
@@ -12,6 +12,8 @@ import {
 } from '../preview/embedViewportHeight';
 import { getDiagramPages, resolvePageFromSubpath, ensureMxfile, type DiagramPage } from '../model/xmlUtils';
 import { FileSource } from './FileSource';
+import { DualFormatFileSource } from './DualFormatFileSource';
+import { dualFormatOf } from '../model/dualFormat';
 import { DRAWIO_FILE_EXT } from '../constants';
 import { pinEmbedPage } from './pinEmbedPage';
 import type DrawioPlugin from '../main';
@@ -220,6 +222,77 @@ class DrawioFileEmbed extends MarkdownRenderChild {
       await this.render();
     }
   }
+}
+
+/**
+ * Give dual-format image embeds (`![[diagram.drawio.svg]]` / `.drawio.png`) the
+ * same click-to-edit hotspot the other previews have.
+ *
+ * These render through Obsidian's own image embed — a plain `<img>` — so, unlike
+ * `.drawio` embeds, they can't go through the embed registry: that registers by
+ * final extension, and `svg`/`png` belong to every image, not just ours. A
+ * Reading-view markdown post-processor is the right seam: it decorates the
+ * already-rendered image span with the shared click action + hover hint, without
+ * changing how the image itself renders.
+ *
+ * Scope, by design:
+ *  - Reading view only. Post-processors don't run over Live Preview's embed
+ *    widgets; the diagram still shows there (native image), it just isn't
+ *    clickable-to-edit. `.drawio` embeds get both modes only because the embed
+ *    registry does.
+ *  - Desktop only. Editing needs the desktop editor; on mobile the native image
+ *    (with its own tap-to-zoom) is left completely untouched.
+ *  - The **Interactive viewer** click action falls back to the editor here:
+ *    the viewer drives the sanitized SVG previews, and a native `<img>` has
+ *    none to explore.
+ *  - The standalone `.drawio.svg`/`.drawio.png` file tab opens in Obsidian's
+ *    native image view, which we deliberately don't intercept (it would mean
+ *    claiming every `.svg`/`.png`); the "Edit drawio diagram" file-menu item and
+ *    command cover editing there.
+ */
+export function registerDualFormatEmbeds(plugin: DrawioPlugin) {
+  const resolveAction = () => {
+    const action = resolveClickAction(plugin.settings.previewClickAction, 'file');
+    return action.kind === 'interactive' ? resolveClickAction('editor', 'file') : action;
+  };
+  plugin.registerMarkdownPostProcessor((el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+    if (!Platform.isDesktopApp) return;
+    for (const span of Array.from(el.querySelectorAll<HTMLElement>('.internal-embed'))) {
+      if (span.dataset.drawioDualformat === '1') continue;
+      const rawSrc = span.getAttribute('src');
+      if (!rawSrc) continue;
+      // Split off any `#subpath` before the suffix check (dual-format files
+      // have no page anchors today, but be robust to a stray '#').
+      const hashIndex = rawSrc.indexOf('#');
+      const path = hashIndex === -1 ? rawSrc : rawSrc.slice(0, hashIndex);
+      const format = dualFormatOf(path);
+      if (!format) continue;
+      const file = plugin.app.metadataCache.getFirstLinkpathDest(path, ctx.sourcePath);
+      if (!(file instanceof TFile)) continue;
+      span.dataset.drawioDualformat = '1';
+
+      span.addClass('drawio-dualformat-embed');
+      const action = resolveAction();
+      span.setAttribute('title', action.title);
+      span.toggleClass('drawio-no-action', action.kind === 'none');
+      if (action.hint) addEditHint(span, action.hint.label, action.hint.icon);
+
+      // Capture phase so we pre-empt any native click behavior on the <img>
+      // (e.g. lightbox); the action is re-resolved at click time so a settings
+      // change applies to already-decorated embeds.
+      span.addEventListener('click', (e) => {
+        const current = resolveAction();
+        if (current.kind === 'none') return; // leave native image behavior alone
+        e.preventDefault();
+        e.stopPropagation();
+        if (current.kind === 'editor') {
+          plugin.openEditor(new DualFormatFileSource(plugin.app, file, format));
+        } else if (current.kind === 'defaultApp') {
+          openWithDefaultApp(plugin.app, file.path);
+        }
+      }, true);
+    }
+  });
 }
 
 /** Reading-view-only fallback when the embed registry is unavailable. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,8 +42,11 @@ export default class DrawioPlugin extends Plugin {
     }
     this.registerExtensions([DRAWIO_FILE_EXT], DRAWIO_VIEW_TYPE);
 
-    const { registerDrawioEmbeds } = await import('./file/EmbedRenderer');
+    const { registerDrawioEmbeds, registerDualFormatEmbeds } = await import('./file/EmbedRenderer');
     registerDrawioEmbeds(this);
+    // Click-to-edit for dual-format image embeds (self-gates to desktop +
+    // Reading view internally, so it's safe to register unconditionally).
+    registerDualFormatEmbeds(this);
 
     // Preview alignment is a body-level class (see styles.css), so flipping
     // the setting realigns already-rendered previews — including ones Obsidian

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,10 @@
 /* ---- Inline previews (code blocks & embeds) ---- */
 .drawio-codeblock { position: relative; cursor: pointer; }
 .drawio-embed { position: relative; cursor: pointer; display: inline-block; max-width: 100%; }
+/* Dual-format image embeds (`![[x.drawio.svg]]`): Obsidian renders the native
+   <img>; we only add the click-to-edit hotspot + hover hint on top, so the
+   span needs a positioning context and the pointer affordance. */
+.drawio-dualformat-embed { position: relative; cursor: pointer; }
 .drawio-preview { width: 100%; overflow: auto; text-align: center; }
 /* The extracted SVG carries explicit width/height/viewBox (see ViewerRenderer),
    so it renders at its natural diagram size and scales down to fit; centre it. */
@@ -29,10 +33,13 @@ body.drawio-align-left .drawio-preview svg { margin: 0; }
 .drawio-edit-hint-icon { display: inline-flex; }
 .drawio-codeblock:hover .drawio-edit-hint,
 .drawio-embed:hover .drawio-edit-hint,
+.drawio-dualformat-embed:hover .drawio-edit-hint,
 .drawio-codeblock:focus-within .drawio-edit-hint,
-.drawio-embed:focus-within .drawio-edit-hint { opacity: .92; }
+.drawio-embed:focus-within .drawio-edit-hint,
+.drawio-dualformat-embed:focus-within .drawio-edit-hint { opacity: .92; }
 /* Previews whose click action is "Do nothing" shouldn't advertise clickability. */
-.drawio-codeblock.drawio-no-action, .drawio-embed.drawio-no-action { cursor: default; }
+.drawio-codeblock.drawio-no-action, .drawio-embed.drawio-no-action,
+.drawio-dualformat-embed.drawio-no-action { cursor: default; }
 
 /* Interactive viewer viewport and controls. */
 .drawio-interactive .drawio-preview { user-select: none; }

--- a/tests/dualFormatEmbed.dom.test.ts
+++ b/tests/dualFormatEmbed.dom.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Same viewer stub as the other embed tests: keep the module load fast and off
+// the real vendored viewer under jsdom.
+vi.mock('../src/preview/viewer.min.txt', () => ({ default: 'window.GraphViewer = window.GraphViewer || undefined;' }));
+
+import { Platform, TFile } from 'obsidian';
+import { registerDualFormatEmbeds } from '../src/file/EmbedRenderer';
+import { DualFormatFileSource } from '../src/file/DualFormatFileSource';
+import type { PreviewClickAction } from '../src/settings';
+import type DrawioPlugin from '../src/main';
+
+type PostProcessor = (el: HTMLElement, ctx: { sourcePath: string }) => void;
+
+function fakePlugin(previewClickAction: PreviewClickAction = 'editor') {
+  let processor: PostProcessor | undefined;
+  const openEditor = vi.fn();
+  const openWithDefaultApp = vi.fn();
+  const files = new Map<string, TFile>();
+  const raw = {
+    app: {
+      metadataCache: {
+        getFirstLinkpathDest: (path: string) => {
+          const existing = files.get(path);
+          if (existing) return existing;
+          // Any linkpath resolves to a TFile with that path (enough for these tests).
+          const f = Object.assign(new TFile(), { path, basename: path.replace(/\.[^.]+$/, '') });
+          files.set(path, f);
+          return f;
+        },
+      },
+      openWithDefaultApp,
+    },
+    settings: { previewClickAction },
+    openEditor,
+    registerMarkdownPostProcessor: (cb: PostProcessor) => { processor = cb; },
+  };
+  return {
+    plugin: raw as unknown as DrawioPlugin,
+    run: (el: HTMLElement) => processor!(el, { sourcePath: 'note.md' }),
+    openEditor,
+    openWithDefaultApp,
+  };
+}
+
+/** Build a Reading-view-like image embed span with an inner <img>. */
+function makeEmbed(src: string): { span: HTMLElement; img: HTMLElement } {
+  const container = document.createElement('div');
+  const span = document.createElement('div');
+  span.className = 'internal-embed media-embed image-embed';
+  span.setAttribute('src', src);
+  const img = document.createElement('img');
+  span.appendChild(img);
+  container.appendChild(span);
+  return { span, img };
+}
+
+describe('dual-format image embeds — click-to-edit', () => {
+  const originalIsDesktopApp = Platform.isDesktopApp;
+  afterEach(() => { Platform.isDesktopApp = originalIsDesktopApp; });
+
+  it('decorates a .drawio.svg embed and opens the editor on click', () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run, openEditor } = fakePlugin('editor');
+    registerDualFormatEmbeds(plugin);
+
+    const { span, img } = makeEmbed('diagram.drawio.svg');
+    run(span.parentElement as HTMLElement);
+
+    expect(span.classList.contains('drawio-dualformat-embed')).toBe(true);
+    expect(span.dataset.drawioDualformat).toBe('1');
+    expect(span.getAttribute('title')).toBe('Click to edit diagram');
+    expect(span.querySelector('.drawio-edit-hint')).not.toBeNull();
+
+    // A click on the inner <img> is caught by our capture-phase handler.
+    img.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(openEditor).toHaveBeenCalledTimes(1);
+    expect(openEditor.mock.calls[0]?.[0]).toBeInstanceOf(DualFormatFileSource);
+  });
+
+  it('opens the default app under the "defaultApp" action', () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run, openEditor, openWithDefaultApp } = fakePlugin('defaultApp');
+    registerDualFormatEmbeds(plugin);
+
+    const { span, img } = makeEmbed('pic.drawio.png');
+    run(span.parentElement as HTMLElement);
+    img.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(openWithDefaultApp).toHaveBeenCalledWith('pic.drawio.png');
+    expect(openEditor).not.toHaveBeenCalled();
+  });
+
+  it('adds no hint and does nothing on click under "none"', () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run, openEditor, openWithDefaultApp } = fakePlugin('none');
+    registerDualFormatEmbeds(plugin);
+
+    const { span, img } = makeEmbed('diagram.drawio.svg');
+    run(span.parentElement as HTMLElement);
+
+    expect(span.querySelector('.drawio-edit-hint')).toBeNull();
+    expect(span.classList.contains('drawio-no-action')).toBe(true);
+    img.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(openEditor).not.toHaveBeenCalled();
+    expect(openWithDefaultApp).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the editor under "interactive" — a native <img> has no SVG to explore', () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run, openEditor } = fakePlugin('interactive');
+    registerDualFormatEmbeds(plugin);
+
+    const { span, img } = makeEmbed('diagram.drawio.svg');
+    run(span.parentElement as HTMLElement);
+
+    expect(span.getAttribute('title')).toBe('Click to edit diagram');
+    img.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(openEditor).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores plain images and .drawio embeds', () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run } = fakePlugin('editor');
+    registerDualFormatEmbeds(plugin);
+
+    for (const src of ['photo.svg', 'chart.png', 'diagram.drawio']) {
+      const { span } = makeEmbed(src);
+      run(span.parentElement as HTMLElement);
+      expect(span.classList.contains('drawio-dualformat-embed')).toBe(false);
+      expect(span.dataset.drawioDualformat).toBeUndefined();
+    }
+  });
+
+  it('does nothing on mobile — the native image is left untouched', () => {
+    Platform.isDesktopApp = false;
+    const { plugin, run, openEditor } = fakePlugin('editor');
+    registerDualFormatEmbeds(plugin);
+
+    const { span, img } = makeEmbed('diagram.drawio.svg');
+    run(span.parentElement as HTMLElement);
+
+    expect(span.classList.contains('drawio-dualformat-embed')).toBe(false);
+    img.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(openEditor).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — a re-processed span is not double-decorated', () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run } = fakePlugin('editor');
+    registerDualFormatEmbeds(plugin);
+
+    const { span } = makeEmbed('diagram.drawio.svg');
+    const parent = span.parentElement as HTMLElement;
+    run(parent);
+    run(parent);
+    expect(parent.querySelectorAll('.drawio-edit-hint').length).toBe(1);
+  });
+});


### PR DESCRIPTION
Part of the 0.6.0 plan: make the editing entry point consistent across all three render surfaces.

`![[diagram.drawio.svg]]` / `![[diagram.drawio.png]]` embeds render through Obsidian's own image embed (a plain `<img>`), so the only way to edit them was the right-click file menu — next to click-to-edit `.drawio` embeds this read as broken rather than intentional. A Reading-view markdown post-processor now decorates those embed spans with the shared click action and hover hint, respecting **Preview click action**.

Scope, by design:
- Reading view + desktop only; Live Preview and mobile keep the untouched native image.
- **Interactive viewer** falls back to opening the editor for these embeds — the viewer drives sanitized SVG previews, and a native `<img>` has none to explore (covered by a test).
- The standalone `.drawio.svg`/`.drawio.png` file tab stays on Obsidian's native image view; the file-menu **Edit drawio diagram** entry covers it.

Validation: full suite (368 tests / 47 files, including 7 new dual-format embed tests) and production build pass on top of the merged interactive-viewer base; manual test checklist added to `docs/MANUAL_TESTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)