### PR TITLE
fix: resolve all 15 interactive-viewer review findings from #21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@codemirror/view": "^6.38.6",
         "@types/node": "^22.15.17",
         "esbuild": "0.25.5",
         "fflate": "^0.8.3",
@@ -38,7 +39,6 @@
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -49,7 +49,6 @@
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -609,8 +608,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.61.0",
@@ -1208,8 +1206,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -1980,8 +1977,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -2685,8 +2681,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@codemirror/view": "^6.38.6",
     "@types/node": "^22.15.17",
     "esbuild": "0.25.5",
     "fflate": "^0.8.3",

--- a/src/codeblock/DrawioCodeBlock.ts
+++ b/src/codeblock/DrawioCodeBlock.ts
@@ -3,7 +3,7 @@ import { renderPreview } from '../preview/ViewerRenderer';
 import { renderPageControl } from '../preview/pageControl';
 import { addEditHint } from '../preview/editHint';
 import { resolveClickAction, resolveEditButtonAction } from '../preview/clickAction';
-import { InteractiveViewerController } from '../preview/interactiveViewer';
+import { mountInteractiveViewer, type InteractiveMountHandle } from '../preview/interactiveMount';
 import {
   readCodeBlockViewportHeight, writeCodeBlockViewportHeight,
 } from '../preview/viewportHeight';
@@ -23,9 +23,15 @@ async function renderCodeBlock(
   ctx: MarkdownPostProcessorContext,
 ): Promise<void> {
   const action = resolveClickAction(plugin.settings.previewClickAction, 'codeblock');
-  const initialHeight = Platform.isDesktopApp && action.kind === 'interactive'
-    ? await readCodeBlockViewportHeight(plugin.app, ctx, el, source)
-    : null;
+  let initialHeight: number | null = null;
+  if (Platform.isDesktopApp && action.kind === 'interactive') {
+    try {
+      initialHeight = await readCodeBlockViewportHeight(plugin.app, ctx, el, source);
+    } catch {
+      // A failed metadata read must never abort rendering the diagram itself.
+      initialHeight = null;
+    }
+  }
   const wrapper = el.createDiv({ cls: 'drawio-codeblock' });
   wrapper.setAttribute('title', Platform.isDesktopApp ? action.title : 'Drawio diagram');
   wrapper.toggleClass('drawio-no-action', Platform.isDesktopApp && action.kind === 'none');
@@ -34,7 +40,7 @@ async function renderCodeBlock(
   const wrapped = ensureMxfile(source);
   const pages = getDiagramPages(wrapped);
   let currentPage = 0;
-  let interactive: InteractiveViewerController | null = null;
+  let interactive: InteractiveMountHandle | null = null;
   renderPreview(preview, source, { ...plugin.previewOpts(), page: currentPage });
 
   if (pages.length > 1) {
@@ -55,10 +61,11 @@ async function renderCodeBlock(
   }
 
   if (Platform.isDesktopApp) {
-    interactive = new InteractiveViewerController(wrapper, preview, {
+    interactive = mountInteractiveViewer(wrapper, preview, {
       isEnabled: () =>
         resolveClickAction(plugin.settings.previewClickAction, 'codeblock').kind === 'interactive',
       initialHeight: initialHeight ?? undefined,
+      loadPersistedHeight: () => readCodeBlockViewportHeight(plugin.app, ctx, el, source),
       onHeightCommit: (height) => {
         void writeCodeBlockViewportHeight(plugin.app, ctx, el, source, height).then((written) => {
           if (!written) new Notice('Drawio: could not save the viewer height for this code block.');
@@ -72,9 +79,8 @@ async function renderCodeBlock(
           plugin.openEditor(new CodeBlockSource(plugin.app, ctx, el, source));
         }
       },
+      onController: (controller) => { ctx.addChild(controller); },
     });
-    interactive.bindSvg(preview.querySelector('svg'));
-    ctx.addChild(interactive);
   }
 
   // Click anywhere on the diagram (the centered hint shows on hover). The

--- a/src/codeblock/DrawioCodeBlock.ts
+++ b/src/codeblock/DrawioCodeBlock.ts
@@ -4,6 +4,7 @@ import { renderPageControl } from '../preview/pageControl';
 import { addEditHint } from '../preview/editHint';
 import { resolveClickAction, resolveEditButtonAction } from '../preview/clickAction';
 import { mountInteractiveViewer, type InteractiveMountHandle } from '../preview/interactiveMount';
+import { SectionLifecycle } from '../preview/sectionLifecycle';
 import {
   readCodeBlockViewportHeight, writeCodeBlockViewportHeight,
 } from '../preview/viewportHeight';
@@ -61,25 +62,35 @@ async function renderCodeBlock(
   }
 
   if (Platform.isDesktopApp) {
-    interactive = mountInteractiveViewer(wrapper, preview, {
-      isEnabled: () =>
-        resolveClickAction(plugin.settings.previewClickAction, 'codeblock').kind === 'interactive',
-      initialHeight: initialHeight ?? undefined,
-      loadPersistedHeight: () => readCodeBlockViewportHeight(plugin.app, ctx, el, source),
-      onHeightCommit: (height) => {
-        void writeCodeBlockViewportHeight(plugin.app, ctx, el, source, height).then((written) => {
-          if (!written) new Notice('Drawio: could not save the viewer height for this code block.');
-        }).catch((err) => {
-          new Notice(`Drawio: could not save viewer height — ${String(err)}`);
-        });
-      },
-      onEdit: () => {
-        const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'codeblock');
-        if (editAction.kind === 'editor') {
-          plugin.openEditor(new CodeBlockSource(plugin.app, ctx, el, source));
-        }
-      },
-      onController: (controller) => { ctx.addChild(controller); },
+    // The section may have been torn down while the stored-height read above
+    // was in flight (a child added to an unloaded owner is stored but never
+    // loaded, so nothing registered then would ever be disposed). Mount only
+    // once Obsidian actually loads this section's children, and tie disposal
+    // to the section's unload.
+    const lifecycle = new SectionLifecycle(wrapper);
+    ctx.addChild(lifecycle);
+    lifecycle.whenReady(() => {
+      const handle = mountInteractiveViewer(wrapper, preview, {
+        isEnabled: () =>
+          resolveClickAction(plugin.settings.previewClickAction, 'codeblock').kind === 'interactive',
+        initialHeight: initialHeight ?? undefined,
+        loadPersistedHeight: () => readCodeBlockViewportHeight(plugin.app, ctx, el, source),
+        onHeightCommit: (height) => {
+          void writeCodeBlockViewportHeight(plugin.app, ctx, el, source, height).then((written) => {
+            if (!written) new Notice('Drawio: could not save the viewer height for this code block.');
+          }).catch((err) => {
+            new Notice(`Drawio: could not save viewer height — ${String(err)}`);
+          });
+        },
+        onEdit: () => {
+          const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'codeblock');
+          if (editAction.kind === 'editor') {
+            plugin.openEditor(new CodeBlockSource(plugin.app, ctx, el, source));
+          }
+        },
+      });
+      interactive = handle;
+      lifecycle.register(() => handle.dispose());
     });
   }
 

--- a/src/codeblock/locateBlock.ts
+++ b/src/codeblock/locateBlock.ts
@@ -3,40 +3,56 @@ export interface BlockRange { start: number; end: number; } // 0-based fence lin
 const OPEN_RE = /^\s*(```+|~~~+)\s*drawio\s*$/;
 const CLOSE_RE = /^\s*(```+|~~~+)\s*$/;
 
+/** Drop a trailing CR so CRLF notes compare equal to the LF text Obsidian hands processors. */
+function stripCr(line: string): string {
+  return line.endsWith('\r') ? line.slice(0, -1) : line;
+}
+
 /**
- * Find a fenced ```drawio block whose body (joined and trimmed) equals
- * `expectedBody` (trimmed). Returns the opening/closing fence line indices,
- * or null if no such block exists. Content-matching is robust against line
- * shifts and disambiguates multiple drawio blocks.
+ * Find every fenced ```drawio block whose body (joined and trimmed) equals
+ * `expectedBody` (trimmed). Returns the opening/closing fence line indices of
+ * each match, in document order. This is the single source of truth for the
+ * drawio fence grammar — extend here, not in per-feature copies.
  */
-export function locateDrawioBlock(lines: string[], expectedBody: string): BlockRange | null {
+export function locateAllDrawioBlocks(lines: string[], expectedBody: string): BlockRange[] {
   const want = expectedBody.trim();
+  const matches: BlockRange[] = [];
   for (let i = 0; i < lines.length; i++) {
-    if (!OPEN_RE.test(lines[i] ?? '')) continue;
+    if (!OPEN_RE.test(stripCr(lines[i] ?? ''))) continue;
     for (let j = i + 1; j < lines.length; j++) {
-      if (CLOSE_RE.test(lines[j] ?? '')) {
-        const body = lines.slice(i + 1, j).join('\n').trim();
-        if (body === want) return { start: i, end: j };
+      if (CLOSE_RE.test(stripCr(lines[j] ?? ''))) {
+        const body = lines.slice(i + 1, j).map(stripCr).join('\n').trim();
+        if (body === want) matches.push({ start: i, end: j });
         i = j; // resume scanning after this block
         break;
       }
     }
   }
-  return null;
+  return matches;
+}
+
+/**
+ * Find the first fenced ```drawio block whose body (joined and trimmed) equals
+ * `expectedBody` (trimmed). Returns the opening/closing fence line indices,
+ * or null if no such block exists. Content-matching is robust against line
+ * shifts and disambiguates multiple drawio blocks.
+ */
+export function locateDrawioBlock(lines: string[], expectedBody: string): BlockRange | null {
+  return locateAllDrawioBlocks(lines, expectedBody)[0] ?? null;
 }
 
 /**
  * Find the fenced ```drawio block that contains `line`, counting the opening
  * and closing fence lines as inside. Same fence grammar and scan order as
- * `locateDrawioBlock` above (single source of truth for fence parsing).
+ * `locateAllDrawioBlocks` above (single source of truth for fence parsing).
  * Returns null when the line is outside every block, or when the block the
  * line sits in is unterminated.
  */
 export function locateDrawioBlockAtLine(lines: string[], line: number): BlockRange | null {
   for (let i = 0; i < lines.length; i++) {
-    if (!OPEN_RE.test(lines[i] ?? '')) continue;
+    if (!OPEN_RE.test(stripCr(lines[i] ?? ''))) continue;
     for (let j = i + 1; j < lines.length; j++) {
-      if (CLOSE_RE.test(lines[j] ?? '')) {
+      if (CLOSE_RE.test(stripCr(lines[j] ?? ''))) {
         if (line >= i && line <= j) return { start: i, end: j };
         i = j; // resume scanning after this block
         break;

--- a/src/file/EmbedRenderer.ts
+++ b/src/file/EmbedRenderer.ts
@@ -6,7 +6,7 @@ import { addEditHint } from '../preview/editHint';
 import {
   resolveClickAction, resolveEditButtonAction, openWithDefaultApp,
 } from '../preview/clickAction';
-import { InteractiveViewerController } from '../preview/interactiveViewer';
+import { mountInteractiveViewer, type InteractiveMountHandle } from '../preview/interactiveMount';
 import {
   readEmbedViewportHeight, writeEmbedViewportHeight,
 } from '../preview/embedViewportHeight';
@@ -17,6 +17,9 @@ import { dualFormatOf } from '../model/dualFormat';
 import { DRAWIO_FILE_EXT } from '../constants';
 import { pinEmbedPage } from './pinEmbedPage';
 import type DrawioPlugin from '../main';
+
+/** Trailing debounce for note-modify triggered height re-reads (keystroke bursts). */
+const STORED_HEIGHT_DEBOUNCE_MS = 250;
 
 /**
  * Make `![[diagram.drawio]]` embeds render the diagram (and open the editor on
@@ -53,7 +56,10 @@ interface EmbedRegistry {
 class DrawioFileEmbed extends MarkdownRenderChild {
   private currentPage = 0;
   private pageResolvedFromSubpath = false;
-  private interactive: InteractiveViewerController | null = null;
+  private interactive: InteractiveMountHandle | null = null;
+  /** Invalidates in-flight render() awaits when a newer render supersedes them. */
+  private renderGeneration = 0;
+  private storedHeightTimer: number | null = null;
 
   constructor(
     private plugin: DrawioPlugin,
@@ -88,43 +94,71 @@ class DrawioFileEmbed extends MarkdownRenderChild {
     }));
     if (this.sourcePath) {
       this.registerEvent(this.plugin.app.vault.on('modify', (f) => {
-        if (!(f instanceof TFile) || f.path !== this.sourcePath || !this.interactive) return;
-        applyStoredEmbedHeight(
-          this.plugin, this.interactive, this.sourcePath!, this.file, this.subpath,
-          undefined, this.containerEl,
-        );
+        if (!(f instanceof TFile) || f.path !== this.sourcePath) return;
+        this.scheduleStoredHeightRefresh();
       }));
     }
   }
 
   onunload(): void {
+    this.renderGeneration += 1;
+    this.cancelStoredHeightRefresh();
     this.interactive?.dispose();
     this.interactive = null;
   }
 
+  /**
+   * Debounced: every keystroke in the owning note fires `modify`, and each
+   * refresh costs a note read plus a metadata locate per embed — only the
+   * trailing edit of a burst matters.
+   */
+  private scheduleStoredHeightRefresh(): void {
+    if (!this.sourcePath || !this.interactive?.controller) return;
+    const win = this.containerEl.ownerDocument.defaultView ?? window;
+    this.cancelStoredHeightRefresh(win);
+    this.storedHeightTimer = win.setTimeout(() => {
+      this.storedHeightTimer = null;
+      if (!this.interactive || !this.sourcePath) return;
+      applyStoredEmbedHeight(
+        this.plugin, this.interactive, this.sourcePath, this.file, this.subpath,
+        undefined, this.containerEl,
+      );
+    }, STORED_HEIGHT_DEBOUNCE_MS);
+  }
+
+  private cancelStoredHeightRefresh(win?: Window): void {
+    if (this.storedHeightTimer === null) return;
+    (win ?? this.containerEl.ownerDocument.defaultView ?? window)
+      .clearTimeout(this.storedHeightTimer);
+    this.storedHeightTimer = null;
+  }
+
   private async render(): Promise<void> {
+    const generation = ++this.renderGeneration;
     const el = this.containerEl;
     this.interactive?.dispose();
     this.interactive = null;
     el.empty();
     el.addClass('drawio-embed');
-    if (this.sourcePath) markEmbedInsertion(el, this.sourcePath, this.file, this.subpath);
     const action = resolveClickAction(this.plugin.settings.previewClickAction, 'file');
     let initialHeight: number | null = null;
     if (Platform.isDesktopApp && action.kind === 'interactive' && this.sourcePath) {
       try {
         initialHeight = await readEmbedViewportHeight(
           this.plugin.app, this.sourcePath, this.file, this.subpath,
-          undefined, undefined, getEmbedOccurrence(el), getLivePreviewSourceOffset(el),
+          undefined, undefined, getLivePreviewSourceOffset(el),
         );
       } catch {
         initialHeight = null;
       }
+      // A newer render (or unload) superseded this one while reading.
+      if (generation !== this.renderGeneration) return;
     }
     el.setAttribute('title', Platform.isDesktopApp ? action.title : 'Drawio diagram');
     el.toggleClass('drawio-no-action', Platform.isDesktopApp && action.kind === 'none');
     try {
       const xml = await this.plugin.app.vault.read(this.file);
+      if (generation !== this.renderGeneration) return;
       const wrapped = ensureMxfile(xml);
       const pages = getDiagramPages(wrapped);
 
@@ -161,14 +195,18 @@ class DrawioFileEmbed extends MarkdownRenderChild {
         addEditHint(el, action.hint.label, action.hint.icon);
       }
       if (Platform.isDesktopApp) {
-        this.interactive = new InteractiveViewerController(el, preview, {
+        this.interactive = mountInteractiveViewer(el, preview, {
           isEnabled: () =>
             resolveClickAction(this.plugin.settings.previewClickAction, 'file').kind === 'interactive',
           initialHeight: initialHeight ?? undefined,
+          loadPersistedHeight: this.sourcePath ? () => readEmbedViewportHeight(
+            this.plugin.app, this.sourcePath!, this.file, this.subpath,
+            undefined, undefined, getLivePreviewSourceOffset(el),
+          ) : undefined,
           onHeightCommit: this.sourcePath ? (height) => {
             commitEmbedHeight(
               this.plugin, this.sourcePath!, this.file, this.subpath, height,
-              undefined, undefined, getEmbedOccurrence(el), getLivePreviewSourceOffset(el),
+              undefined, undefined, getLivePreviewSourceOffset(el),
             );
           } : undefined,
           onEdit: () => {
@@ -180,13 +218,13 @@ class DrawioFileEmbed extends MarkdownRenderChild {
             }
           },
         });
-        this.interactive.bindSvg(preview.querySelector('svg'));
         scheduleStoredEmbedHeight(
           this.plugin, this.interactive, this.sourcePath, this.file, this.subpath,
           undefined, el,
         );
       }
     } catch (err) {
+      if (generation !== this.renderGeneration) return;
       el.createDiv({ cls: 'drawio-error', text: `Failed to render diagram: ${String(err)}` });
     }
     // Wire the click handler once (survives re-renders; el.empty() keeps the
@@ -295,6 +333,18 @@ export function registerDualFormatEmbeds(plugin: DrawioPlugin) {
   });
 }
 
+/**
+ * Tracks whether the section that owns a fallback-rendered embed is still
+ * alive. Registered with `ctx.addChild` synchronously — before the async
+ * renders — so work that completes after the section was torn down can detect
+ * it and skip mounting anything that would leak.
+ */
+class EmbedSectionLifecycle extends MarkdownRenderChild {
+  active = false;
+  onload(): void { this.active = true; }
+  onunload(): void { this.active = false; }
+}
+
 /** Reading-view-only fallback when the embed registry is unavailable. */
 function registerEmbedPostProcessor(plugin: DrawioPlugin) {
   plugin.registerMarkdownPostProcessor((el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
@@ -327,7 +377,12 @@ function registerEmbedPostProcessor(plugin: DrawioPlugin) {
           openWithDefaultApp(plugin.app, file.path);
         }
       });
-      void renderEmbedInto(plugin, span, file, subpath, ctx);
+      // Register the lifecycle tracker before any awaits: if Obsidian tears
+      // the section down while the render below is still reading files, the
+      // tracker flips inactive and the interactive mount is skipped.
+      const lifecycle = new EmbedSectionLifecycle(span);
+      ctx.addChild(lifecycle);
+      void renderEmbedInto(plugin, span, file, subpath, ctx, lifecycle);
     }
   });
 }
@@ -338,24 +393,24 @@ async function renderEmbedInto(
   file: TFile,
   subpath: string | undefined,
   ctx: MarkdownPostProcessorContext,
+  lifecycle: EmbedSectionLifecycle,
 ) {
   span.empty();
   span.addClass('drawio-embed');
-  markEmbedInsertion(span, ctx.sourcePath, file, subpath);
   span.removeClasses(['file-embed', 'mod-generic', 'is-loaded']);
   try {
     const xml = await plugin.app.vault.read(file);
     const wrapped = ensureMxfile(xml);
     const pages = getDiagramPages(wrapped);
     const currentPage = resolvePageFromSubpath(pages, subpath);
-    let interactive: InteractiveViewerController | null = null;
+    let interactive: InteractiveMountHandle | null = null;
     let initialHeight: number | null = null;
     if (Platform.isDesktopApp &&
         resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive') {
       try {
         initialHeight = await readEmbedViewportHeight(
           plugin.app, ctx.sourcePath, file, subpath, ctx, span,
-          getEmbedOccurrence(span), getLivePreviewSourceOffset(span),
+          getLivePreviewSourceOffset(span),
         );
       } catch {
         initialHeight = null;
@@ -389,14 +444,28 @@ async function renderEmbedInto(
     if (Platform.isDesktopApp && action.hint) {
       addEditHint(span, action.hint.label, action.hint.icon);
     }
-    if (Platform.isDesktopApp) {
-      interactive = new InteractiveViewerController(span, preview, {
+    // Only mount the interactive controller while the owning section is
+    // alive: this code runs after awaits, and a torn-down section would
+    // never unload a controller registered now (leaking its listeners).
+    if (Platform.isDesktopApp && lifecycle.active) {
+      let storedHeightTimer: number | null = null;
+      lifecycle.register(() => {
+        if (storedHeightTimer !== null) {
+          (span.ownerDocument.defaultView ?? window).clearTimeout(storedHeightTimer);
+          storedHeightTimer = null;
+        }
+      });
+      interactive = mountInteractiveViewer(span, preview, {
         isEnabled: () =>
           resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive',
         initialHeight: initialHeight ?? undefined,
+        loadPersistedHeight: () => readEmbedViewportHeight(
+          plugin.app, ctx.sourcePath, file, subpath, ctx, span,
+          getLivePreviewSourceOffset(span),
+        ),
         onHeightCommit: (height) => {
           commitEmbedHeight(
-            plugin, ctx.sourcePath, file, subpath, height, ctx, span, getEmbedOccurrence(span),
+            plugin, ctx.sourcePath, file, subpath, height, ctx, span,
             getLivePreviewSourceOffset(span),
           );
         },
@@ -408,19 +477,24 @@ async function renderEmbedInto(
             openWithDefaultApp(plugin.app, file.path);
           }
         },
+        onController: (controller) => { lifecycle.addChild(controller); },
       });
-      interactive.bindSvg(preview.querySelector('svg'));
+      const mounted = interactive;
+      lifecycle.register(() => { mounted.dispose(); });
       scheduleStoredEmbedHeight(
-        plugin, interactive, ctx.sourcePath, file, subpath, ctx, span,
+        plugin, mounted, ctx.sourcePath, file, subpath, ctx, span,
       );
-      interactive.registerEvent(plugin.app.vault.on('modify', (changed) => {
-        if (changed instanceof TFile && changed.path === ctx.sourcePath) {
-          applyStoredEmbedHeight(
-            plugin, interactive!, ctx.sourcePath, file, subpath, ctx, span,
-          );
-        }
+      lifecycle.registerEvent(plugin.app.vault.on('modify', (changed) => {
+        if (!(changed instanceof TFile) || changed.path !== ctx.sourcePath) return;
+        const controller = mounted.controller;
+        if (!controller) return;
+        const win = span.ownerDocument.defaultView ?? window;
+        if (storedHeightTimer !== null) win.clearTimeout(storedHeightTimer);
+        storedHeightTimer = win.setTimeout(() => {
+          storedHeightTimer = null;
+          applyStoredEmbedHeight(plugin, mounted, ctx.sourcePath, file, subpath, ctx, span);
+        }, STORED_HEIGHT_DEBOUNCE_MS);
       }));
-      ctx.addChild(interactive);
     }
   } catch (err) {
     span.empty();
@@ -436,16 +510,20 @@ function commitEmbedHeight(
   height: number,
   ctx?: MarkdownPostProcessorContext,
   el?: HTMLElement,
-  occurrence?: number,
   sourceOffset?: number,
 ): void {
   void writeEmbedViewportHeight(
-    plugin.app, sourcePath, file, subpath, height, ctx, el, occurrence, sourceOffset,
+    plugin.app, sourcePath, file, subpath, height, ctx, el, sourceOffset,
   ).then((outcome) => {
     if (outcome === 'ambiguous') {
       new Notice(
         'Drawio: several identical embeds match this insertion. ' +
-        'Resize it in Reading view or give the links distinct page subpaths.',
+        'Resize it in the editing view or give the links distinct page subpaths.',
+      );
+    } else if (outcome === 'unsupported') {
+      new Notice(
+        'Drawio: this embed sits in a table or list where a height comment ' +
+        'cannot be inserted safely; viewer height was not saved.',
       );
     } else if (outcome === 'no-match') {
       new Notice('Drawio: could not locate this embed in the note; viewer height was not saved.');
@@ -457,14 +535,15 @@ function commitEmbedHeight(
 
 function scheduleStoredEmbedHeight(
   plugin: DrawioPlugin,
-  interactive: InteractiveViewerController,
+  interactive: InteractiveMountHandle,
   sourcePath: string | undefined,
   file: TFile,
   subpath: string | undefined,
   ctx: MarkdownPostProcessorContext | undefined,
   el: HTMLElement,
 ): void {
-  if (!sourcePath) return;
+  // Lazily mounted handles read the persisted height at activation instead.
+  if (!sourcePath || !interactive.controller) return;
   const run = () => applyStoredEmbedHeight(
     plugin, interactive, sourcePath, file, subpath, ctx, el,
   );
@@ -475,46 +554,21 @@ function scheduleStoredEmbedHeight(
 
 function applyStoredEmbedHeight(
   plugin: DrawioPlugin,
-  interactive: InteractiveViewerController,
+  interactive: InteractiveMountHandle,
   sourcePath: string,
   file: TFile,
   subpath: string | undefined,
   ctx: MarkdownPostProcessorContext | undefined,
   el: HTMLElement,
 ): void {
+  const controller = interactive.controller;
+  if (!controller) return;
   if (resolveClickAction(plugin.settings.previewClickAction, 'file').kind !== 'interactive') return;
   void readEmbedViewportHeight(
-    plugin.app, sourcePath, file, subpath, ctx, el,
-    getEmbedOccurrence(el), getLivePreviewSourceOffset(el),
+    plugin.app, sourcePath, file, subpath, ctx, el, getLivePreviewSourceOffset(el),
   ).then((height) => {
-    if (height !== null) interactive.applyPersistedHeight(height);
+    if (height !== null) controller.applyPersistedHeight(height);
   }).catch(() => { /* Keep the already rendered automatic height. */ });
-}
-
-function markEmbedInsertion(
-  el: HTMLElement,
-  sourcePath: string,
-  file: TFile,
-  subpath: string | undefined,
-): void {
-  el.dataset.drawioInsertionKey = JSON.stringify([
-    sourcePath,
-    file.path,
-    subpath?.replace(/^#/, '') ?? '',
-  ]);
-}
-
-function getEmbedOccurrence(el: HTMLElement): number {
-  const key = el.dataset.drawioInsertionKey;
-  if (!key) return 0;
-  const scope = el.closest<HTMLElement>(
-    '.markdown-preview-view, .markdown-source-view, .workspace-leaf-content',
-  ) ?? el.parentElement;
-  if (!scope) return 0;
-  const peers = Array.from(scope.querySelectorAll<HTMLElement>('.drawio-embed'))
-    .filter((candidate) => candidate.dataset.drawioInsertionKey === key);
-  const index = peers.indexOf(el);
-  return index === -1 ? 0 : index;
 }
 
 function getLivePreviewSourceOffset(el: HTMLElement): number | undefined {

--- a/src/file/EmbedRenderer.ts
+++ b/src/file/EmbedRenderer.ts
@@ -7,6 +7,7 @@ import {
   resolveClickAction, resolveEditButtonAction, openWithDefaultApp,
 } from '../preview/clickAction';
 import { mountInteractiveViewer, type InteractiveMountHandle } from '../preview/interactiveMount';
+import { SectionLifecycle } from '../preview/sectionLifecycle';
 import {
   readEmbedViewportHeight, writeEmbedViewportHeight,
 } from '../preview/embedViewportHeight';
@@ -20,6 +21,44 @@ import type DrawioPlugin from '../main';
 
 /** Trailing debounce for note-modify triggered height re-reads (keystroke bursts). */
 const STORED_HEIGHT_DEBOUNCE_MS = 250;
+
+interface DebouncedTask {
+  schedule(): void;
+  cancel(): void;
+}
+
+/**
+ * Trailing debounce that always clears a timer on the SAME window that set
+ * it: `getWin` is re-resolved per schedule because the owning element can be
+ * adopted into a popout window between schedules, and clearing a timer id on
+ * the wrong window both leaks the real timer and may cancel an unrelated one.
+ */
+function debounceOnWindow(
+  getWin: () => Window,
+  delayMs: number,
+  task: () => void,
+): DebouncedTask {
+  let timer: number | null = null;
+  let timerWin: Window | null = null;
+  const cancel = (): void => {
+    if (timer !== null && timerWin) timerWin.clearTimeout(timer);
+    timer = null;
+    timerWin = null;
+  };
+  return {
+    cancel,
+    schedule(): void {
+      cancel();
+      const win = getWin();
+      timerWin = win;
+      timer = win.setTimeout(() => {
+        timer = null;
+        timerWin = null;
+        task();
+      }, delayMs);
+    },
+  };
+}
 
 /**
  * Make `![[diagram.drawio]]` embeds render the diagram (and open the editor on
@@ -59,7 +98,19 @@ class DrawioFileEmbed extends MarkdownRenderChild {
   private interactive: InteractiveMountHandle | null = null;
   /** Invalidates in-flight render() awaits when a newer render supersedes them. */
   private renderGeneration = 0;
-  private storedHeightTimer: number | null = null;
+  /** Set on unload; render() must become a no-op afterwards (see below). */
+  private torndown = false;
+  private storedHeightRefresh: DebouncedTask = debounceOnWindow(
+    () => this.containerEl.ownerDocument.defaultView ?? window,
+    STORED_HEIGHT_DEBOUNCE_MS,
+    () => {
+      if (!this.interactive || !this.sourcePath) return;
+      applyStoredEmbedHeight(
+        this.plugin, this.interactive, this.sourcePath, this.file, this.subpath,
+        undefined, this.containerEl,
+      );
+    },
+  );
 
   constructor(
     private plugin: DrawioPlugin,
@@ -93,60 +144,45 @@ class DrawioFileEmbed extends MarkdownRenderChild {
       if (f instanceof TFile && f.path === this.file.path) void this.render();
     }));
     if (this.sourcePath) {
+      // Debounced: every keystroke in the owning note fires `modify`, and
+      // each refresh costs a note read plus a metadata locate per embed —
+      // only the trailing edit of a burst matters.
       this.registerEvent(this.plugin.app.vault.on('modify', (f) => {
         if (!(f instanceof TFile) || f.path !== this.sourcePath) return;
-        this.scheduleStoredHeightRefresh();
+        if (!this.interactive?.controller) return;
+        this.storedHeightRefresh.schedule();
       }));
     }
   }
 
   onunload(): void {
+    this.torndown = true;
     this.renderGeneration += 1;
-    this.cancelStoredHeightRefresh();
+    this.storedHeightRefresh.cancel();
     this.interactive?.dispose();
     this.interactive = null;
   }
 
-  /**
-   * Debounced: every keystroke in the owning note fires `modify`, and each
-   * refresh costs a note read plus a metadata locate per embed — only the
-   * trailing edit of a burst matters.
-   */
-  private scheduleStoredHeightRefresh(): void {
-    if (!this.sourcePath || !this.interactive?.controller) return;
-    const win = this.containerEl.ownerDocument.defaultView ?? window;
-    this.cancelStoredHeightRefresh(win);
-    this.storedHeightTimer = win.setTimeout(() => {
-      this.storedHeightTimer = null;
-      if (!this.interactive || !this.sourcePath) return;
-      applyStoredEmbedHeight(
-        this.plugin, this.interactive, this.sourcePath, this.file, this.subpath,
-        undefined, this.containerEl,
-      );
-    }, STORED_HEIGHT_DEBOUNCE_MS);
-  }
-
-  private cancelStoredHeightRefresh(win?: Window): void {
-    if (this.storedHeightTimer === null) return;
-    (win ?? this.containerEl.ownerDocument.defaultView ?? window)
-      .clearTimeout(this.storedHeightTimer);
-    this.storedHeightTimer = null;
-  }
-
   private async render(): Promise<void> {
+    // pin() (and any other await-holding caller) can resume after Obsidian
+    // unloaded this component — its vault write makes Obsidian rebuild the
+    // embed widget. Rendering then would mount a controller nothing ever
+    // disposes.
+    if (this.torndown) return;
     const generation = ++this.renderGeneration;
     const el = this.containerEl;
     this.interactive?.dispose();
     this.interactive = null;
     el.empty();
     el.addClass('drawio-embed');
+    if (this.sourcePath) markEmbedInsertion(el, this.sourcePath, this.file, this.subpath);
     const action = resolveClickAction(this.plugin.settings.previewClickAction, 'file');
     let initialHeight: number | null = null;
     if (Platform.isDesktopApp && action.kind === 'interactive' && this.sourcePath) {
       try {
         initialHeight = await readEmbedViewportHeight(
           this.plugin.app, this.sourcePath, this.file, this.subpath,
-          undefined, undefined, getLivePreviewSourceOffset(el),
+          undefined, undefined, getLivePreviewSourceOffset(el), getEmbedOccurrence(el),
         );
       } catch {
         initialHeight = null;
@@ -201,7 +237,7 @@ class DrawioFileEmbed extends MarkdownRenderChild {
           initialHeight: initialHeight ?? undefined,
           loadPersistedHeight: this.sourcePath ? () => readEmbedViewportHeight(
             this.plugin.app, this.sourcePath!, this.file, this.subpath,
-            undefined, undefined, getLivePreviewSourceOffset(el),
+            undefined, undefined, getLivePreviewSourceOffset(el), getEmbedOccurrence(el),
           ) : undefined,
           onHeightCommit: this.sourcePath ? (height) => {
             commitEmbedHeight(
@@ -333,18 +369,6 @@ export function registerDualFormatEmbeds(plugin: DrawioPlugin) {
   });
 }
 
-/**
- * Tracks whether the section that owns a fallback-rendered embed is still
- * alive. Registered with `ctx.addChild` synchronously — before the async
- * renders — so work that completes after the section was torn down can detect
- * it and skip mounting anything that would leak.
- */
-class EmbedSectionLifecycle extends MarkdownRenderChild {
-  active = false;
-  onload(): void { this.active = true; }
-  onunload(): void { this.active = false; }
-}
-
 /** Reading-view-only fallback when the embed registry is unavailable. */
 function registerEmbedPostProcessor(plugin: DrawioPlugin) {
   plugin.registerMarkdownPostProcessor((el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
@@ -377,10 +401,11 @@ function registerEmbedPostProcessor(plugin: DrawioPlugin) {
           openWithDefaultApp(plugin.app, file.path);
         }
       });
-      // Register the lifecycle tracker before any awaits: if Obsidian tears
-      // the section down while the render below is still reading files, the
-      // tracker flips inactive and the interactive mount is skipped.
-      const lifecycle = new EmbedSectionLifecycle(span);
+      // Register the lifecycle tracker before any awaits: mounting below is
+      // queued through it, so a section torn down while the render is still
+      // reading files never receives a controller — and a load that arrives
+      // only after the reads still mounts (whenReady queues the work).
+      const lifecycle = new SectionLifecycle(span);
       ctx.addChild(lifecycle);
       void renderEmbedInto(plugin, span, file, subpath, ctx, lifecycle);
     }
@@ -393,10 +418,11 @@ async function renderEmbedInto(
   file: TFile,
   subpath: string | undefined,
   ctx: MarkdownPostProcessorContext,
-  lifecycle: EmbedSectionLifecycle,
+  lifecycle: SectionLifecycle,
 ) {
   span.empty();
   span.addClass('drawio-embed');
+  markEmbedInsertion(span, ctx.sourcePath, file, subpath);
   span.removeClasses(['file-embed', 'mod-generic', 'is-loaded']);
   try {
     const xml = await plugin.app.vault.read(file);
@@ -410,7 +436,7 @@ async function renderEmbedInto(
       try {
         initialHeight = await readEmbedViewportHeight(
           plugin.app, ctx.sourcePath, file, subpath, ctx, span,
-          getLivePreviewSourceOffset(span),
+          getLivePreviewSourceOffset(span), getEmbedOccurrence(span),
         );
       } catch {
         initialHeight = null;
@@ -444,57 +470,56 @@ async function renderEmbedInto(
     if (Platform.isDesktopApp && action.hint) {
       addEditHint(span, action.hint.label, action.hint.icon);
     }
-    // Only mount the interactive controller while the owning section is
-    // alive: this code runs after awaits, and a torn-down section would
-    // never unload a controller registered now (leaking its listeners).
-    if (Platform.isDesktopApp && lifecycle.active) {
-      let storedHeightTimer: number | null = null;
-      lifecycle.register(() => {
-        if (storedHeightTimer !== null) {
-          (span.ownerDocument.defaultView ?? window).clearTimeout(storedHeightTimer);
-          storedHeightTimer = null;
-        }
+    // The interactive mount is queued through the section lifecycle: it runs
+    // when (and only when) Obsidian loads this section's children — never for
+    // a section already torn down while the reads above were in flight, and
+    // not skipped when the load is dispatched only after those reads.
+    if (Platform.isDesktopApp) {
+      lifecycle.whenReady(() => {
+        const mounted = mountInteractiveViewer(span, preview, {
+          isEnabled: () =>
+            resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive',
+          initialHeight: initialHeight ?? undefined,
+          loadPersistedHeight: () => readEmbedViewportHeight(
+            plugin.app, ctx.sourcePath, file, subpath, ctx, span,
+            getLivePreviewSourceOffset(span), getEmbedOccurrence(span),
+          ),
+          onHeightCommit: (height) => {
+            commitEmbedHeight(
+              plugin, ctx.sourcePath, file, subpath, height, ctx, span,
+              getLivePreviewSourceOffset(span),
+            );
+          },
+          onEdit: () => {
+            const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'file');
+            if (editAction.kind === 'editor') {
+              plugin.openEditor(new FileSource(plugin.app, file));
+            } else if (editAction.kind === 'defaultApp') {
+              openWithDefaultApp(plugin.app, file.path);
+            }
+          },
+        });
+        interactive = mounted;
+        // Single teardown seam: dispose covers both the lazy listeners and
+        // any constructed controller.
+        lifecycle.register(() => { mounted.dispose(); });
+        scheduleStoredEmbedHeight(
+          plugin, mounted, ctx.sourcePath, file, subpath, ctx, span,
+        );
+        const storedHeightRefresh = debounceOnWindow(
+          () => span.ownerDocument.defaultView ?? window,
+          STORED_HEIGHT_DEBOUNCE_MS,
+          () => {
+            applyStoredEmbedHeight(plugin, mounted, ctx.sourcePath, file, subpath, ctx, span);
+          },
+        );
+        lifecycle.register(() => { storedHeightRefresh.cancel(); });
+        lifecycle.registerEvent(plugin.app.vault.on('modify', (changed) => {
+          if (!(changed instanceof TFile) || changed.path !== ctx.sourcePath) return;
+          if (!mounted.controller) return;
+          storedHeightRefresh.schedule();
+        }));
       });
-      interactive = mountInteractiveViewer(span, preview, {
-        isEnabled: () =>
-          resolveClickAction(plugin.settings.previewClickAction, 'file').kind === 'interactive',
-        initialHeight: initialHeight ?? undefined,
-        loadPersistedHeight: () => readEmbedViewportHeight(
-          plugin.app, ctx.sourcePath, file, subpath, ctx, span,
-          getLivePreviewSourceOffset(span),
-        ),
-        onHeightCommit: (height) => {
-          commitEmbedHeight(
-            plugin, ctx.sourcePath, file, subpath, height, ctx, span,
-            getLivePreviewSourceOffset(span),
-          );
-        },
-        onEdit: () => {
-          const editAction = resolveEditButtonAction(plugin.settings.editButtonAction, 'file');
-          if (editAction.kind === 'editor') {
-            plugin.openEditor(new FileSource(plugin.app, file));
-          } else if (editAction.kind === 'defaultApp') {
-            openWithDefaultApp(plugin.app, file.path);
-          }
-        },
-        onController: (controller) => { lifecycle.addChild(controller); },
-      });
-      const mounted = interactive;
-      lifecycle.register(() => { mounted.dispose(); });
-      scheduleStoredEmbedHeight(
-        plugin, mounted, ctx.sourcePath, file, subpath, ctx, span,
-      );
-      lifecycle.registerEvent(plugin.app.vault.on('modify', (changed) => {
-        if (!(changed instanceof TFile) || changed.path !== ctx.sourcePath) return;
-        const controller = mounted.controller;
-        if (!controller) return;
-        const win = span.ownerDocument.defaultView ?? window;
-        if (storedHeightTimer !== null) win.clearTimeout(storedHeightTimer);
-        storedHeightTimer = win.setTimeout(() => {
-          storedHeightTimer = null;
-          applyStoredEmbedHeight(plugin, mounted, ctx.sourcePath, file, subpath, ctx, span);
-        }, STORED_HEIGHT_DEBOUNCE_MS);
-      }));
     }
   } catch (err) {
     span.empty();
@@ -522,8 +547,8 @@ function commitEmbedHeight(
       );
     } else if (outcome === 'unsupported') {
       new Notice(
-        'Drawio: this embed sits in a table or list where a height comment ' +
-        'cannot be inserted safely; viewer height was not saved.',
+        'Drawio: this embed sits in a table, list, or callout title where a ' +
+        'height comment cannot be inserted safely; viewer height was not saved.',
       );
     } else if (outcome === 'no-match') {
       new Notice('Drawio: could not locate this embed in the note; viewer height was not saved.');
@@ -565,10 +590,43 @@ function applyStoredEmbedHeight(
   if (!controller) return;
   if (resolveClickAction(plugin.settings.previewClickAction, 'file').kind !== 'interactive') return;
   void readEmbedViewportHeight(
-    plugin.app, sourcePath, file, subpath, ctx, el, getLivePreviewSourceOffset(el),
+    plugin.app, sourcePath, file, subpath, ctx, el,
+    getLivePreviewSourceOffset(el), getEmbedOccurrence(el),
   ).then((height) => {
     if (height !== null) controller.applyPersistedHeight(height);
   }).catch(() => { /* Keep the already rendered automatic height. */ });
+}
+
+function markEmbedInsertion(
+  el: HTMLElement,
+  sourcePath: string,
+  file: TFile,
+  subpath: string | undefined,
+): void {
+  el.dataset.drawioInsertionKey = JSON.stringify([
+    sourcePath,
+    file.path,
+    subpath?.replace(/^#/, '') ?? '',
+  ]);
+}
+
+/**
+ * Index of this embed among same-key peers currently in the DOM. Used only
+ * to READ heights for otherwise-indistinguishable duplicate embeds (the
+ * pre-existing behavior); never trusted for writes — Reading view
+ * virtualizes offscreen sections out of the DOM, which can skew the index.
+ */
+function getEmbedOccurrence(el: HTMLElement): number {
+  const key = el.dataset.drawioInsertionKey;
+  if (!key) return 0;
+  const scope = el.closest<HTMLElement>(
+    '.markdown-preview-view, .markdown-source-view, .workspace-leaf-content',
+  ) ?? el.parentElement;
+  if (!scope) return 0;
+  const peers = Array.from(scope.querySelectorAll<HTMLElement>('.drawio-embed'))
+    .filter((candidate) => candidate.dataset.drawioInsertionKey === key);
+  const index = peers.indexOf(el);
+  return index === -1 ? 0 : index;
 }
 
 function getLivePreviewSourceOffset(el: HTMLElement): number | undefined {

--- a/src/model/codeBlockEdit.ts
+++ b/src/model/codeBlockEdit.ts
@@ -16,6 +16,10 @@ export function replaceCodeBlockBody(
   const closing = lines[lineEnd] ?? '';
   const before = lines.slice(0, lineStart);
   const after = lines.slice(lineEnd + 1);
-  const bodyLines = newBody.split('\n');
+  // Match the note's dominant line ending: every inserted body line precedes
+  // the closing fence, so in a CRLF note each one needs its CR — otherwise
+  // the write produces mixed line endings.
+  const eol = doc.includes('\r\n') ? '\r' : '';
+  const bodyLines = newBody.split('\n').map((line) => line + eol);
   return [...before, opening, ...bodyLines, closing, ...after].join('\n');
 }

--- a/src/preview/DrawioPreviewFileView.ts
+++ b/src/preview/DrawioPreviewFileView.ts
@@ -4,7 +4,7 @@ import { renderPreview } from './ViewerRenderer';
 import { renderPageControl } from './pageControl';
 import { addEditHint } from './editHint';
 import { resolveClickAction, resolveEditButtonAction, openWithDefaultApp } from './clickAction';
-import { InteractiveViewerController } from './interactiveViewer';
+import { mountInteractiveViewer, type InteractiveMountHandle } from './interactiveMount';
 import { getDiagramPages, ensureMxfile } from '../model/xmlUtils';
 import { FileSource } from '../file/FileSource';
 import type DrawioPlugin from '../main';
@@ -17,7 +17,7 @@ import type DrawioPlugin from '../main';
  * follows the "Preview click action" setting.
  */
 export class DrawioPreviewFileView extends TextFileView {
-  private interactive: InteractiveViewerController | null = null;
+  private interactive: InteractiveMountHandle | null = null;
 
   constructor(leaf: WorkspaceLeaf, private plugin: DrawioPlugin) {
     super(leaf);
@@ -85,7 +85,7 @@ export class DrawioPreviewFileView extends TextFileView {
       addEditHint(previewWrap, action.hint.label, action.hint.icon);
     }
     if (Platform.isDesktopApp) {
-      this.interactive = new InteractiveViewerController(c, preview, {
+      this.interactive = mountInteractiveViewer(c, preview, {
         isEnabled: () =>
           resolveClickAction(this.plugin.settings.previewClickAction, 'file').kind === 'interactive',
         onEdit: () => {
@@ -98,7 +98,6 @@ export class DrawioPreviewFileView extends TextFileView {
           }
         },
       });
-      this.interactive.bindSvg(preview.querySelector('svg'));
     }
   }
 

--- a/src/preview/embedViewportHeight.ts
+++ b/src/preview/embedViewportHeight.ts
@@ -16,11 +16,14 @@ export async function readEmbedViewportHeight(
   ctx?: MarkdownPostProcessorContext,
   el?: HTMLElement,
   sourceOffset?: number,
+  occurrence?: number,
 ): Promise<number | null> {
   const note = app.vault.getAbstractFileByPath(sourcePath);
   if (!(note instanceof TFile)) return null;
   const doc = await app.vault.cachedRead(note);
-  const located = locateEmbed(app, sourcePath, targetFile, subpath, doc, ctx, el, sourceOffset);
+  const located = locateEmbed(
+    app, sourcePath, targetFile, subpath, doc, ctx, el, sourceOffset, occurrence,
+  );
   if (located.outcome !== 'found') return null;
   const offset = resolveCurrentOffset(doc, located.value);
   if (offset === null) return null;
@@ -61,13 +64,15 @@ export async function writeEmbedViewportHeight(
 }
 
 /**
- * Resolve which embed insertion in the note this render belongs to. Only
- * reliable signals are used, in order: the Live Preview source offset (from
- * the CodeMirror DOM position), the Reading-view section range, and finally a
- * single unambiguous candidate. When several identical embeds remain, the
- * result is 'ambiguous' and the caller must not write — a DOM-occurrence
- * index is NOT used as a tiebreaker, because virtualized rendering (Reading
- * view unloads offscreen sections) makes it point at the wrong insertion.
+ * Resolve which embed insertion in the note this render belongs to. Reliable
+ * signals are used in order: the Live Preview source offset (from the
+ * CodeMirror DOM position), the Reading-view section range, then a single
+ * unambiguous candidate. As a READ-ONLY last resort, the caller's
+ * DOM-occurrence index breaks remaining ties — virtualized rendering
+ * (Reading view unloads offscreen sections) can make it point at the wrong
+ * insertion, so writes never pass one: a misread height is cosmetic, a
+ * miswrite corrupts the note. Without any signal the result is 'ambiguous'
+ * and the caller must not write.
  */
 function locateEmbed(
   app: App,
@@ -78,6 +83,7 @@ function locateEmbed(
   ctx?: MarkdownPostProcessorContext,
   el?: HTMLElement,
   sourceOffset?: number,
+  occurrence?: number,
 ): { outcome: 'found'; value: LocatedEmbed } | { outcome: 'no-match' | 'ambiguous' } {
   const embeds = app.metadataCache.getCache(sourcePath)?.embeds ?? [];
   const expectedSubpath = normalizeSubpath(subpath);
@@ -109,9 +115,13 @@ function locateEmbed(
     }
   }
 
-  return candidates.length === 1
-    ? { outcome: 'found', value: { item: candidates[0]!, allItems: embeds } }
-    : { outcome: 'ambiguous' };
+  if (candidates.length === 1) {
+    return { outcome: 'found', value: { item: candidates[0]!, allItems: embeds } };
+  }
+  if (occurrence !== undefined && candidates[occurrence]) {
+    return { outcome: 'found', value: { item: candidates[occurrence]!, allItems: embeds } };
+  }
+  return { outcome: 'ambiguous' };
 }
 
 function sourceLinktext(item: EmbedCache): string {

--- a/src/preview/embedViewportHeight.ts
+++ b/src/preview/embedViewportHeight.ts
@@ -1,17 +1,11 @@
-import { App, MarkdownPostProcessorContext, parseLinktext, TFile } from 'obsidian';
+import { App, EmbedCache, MarkdownPostProcessorContext, parseLinktext, TFile } from 'obsidian';
 import { parseViewportHeightComment, upsertViewportHeightComment } from './viewportHeight';
 
-export type EmbedHeightWriteOutcome = 'written' | 'no-match' | 'ambiguous';
-
-interface EmbedCacheItem {
-  link: string;
-  original: string;
-  position: { start: { offset: number }; end: { offset: number } };
-}
+export type EmbedHeightWriteOutcome = 'written' | 'no-match' | 'ambiguous' | 'unsupported';
 
 interface LocatedEmbed {
-  item: EmbedCacheItem;
-  allItems: EmbedCacheItem[];
+  item: EmbedCache;
+  allItems: EmbedCache[];
 }
 
 export async function readEmbedViewportHeight(
@@ -21,15 +15,12 @@ export async function readEmbedViewportHeight(
   subpath?: string,
   ctx?: MarkdownPostProcessorContext,
   el?: HTMLElement,
-  occurrence?: number,
   sourceOffset?: number,
 ): Promise<number | null> {
   const note = app.vault.getAbstractFileByPath(sourcePath);
   if (!(note instanceof TFile)) return null;
   const doc = await app.vault.cachedRead(note);
-  const located = locateEmbed(
-    app, sourcePath, targetFile, subpath, doc, ctx, el, occurrence, sourceOffset,
-  );
+  const located = locateEmbed(app, sourcePath, targetFile, subpath, doc, ctx, el, sourceOffset);
   if (located.outcome !== 'found') return null;
   const offset = resolveCurrentOffset(doc, located.value);
   if (offset === null) return null;
@@ -45,26 +36,39 @@ export async function writeEmbedViewportHeight(
   height: number,
   ctx?: MarkdownPostProcessorContext,
   el?: HTMLElement,
-  occurrence?: number,
   sourceOffset?: number,
 ): Promise<EmbedHeightWriteOutcome> {
   const note = app.vault.getAbstractFileByPath(sourcePath);
   if (!(note instanceof TFile)) return 'no-match';
   const snapshot = await app.vault.cachedRead(note);
-  const located = locateEmbed(
-    app, sourcePath, targetFile, subpath, snapshot, ctx, el, occurrence, sourceOffset,
-  );
+  const located = locateEmbed(app, sourcePath, targetFile, subpath, snapshot, ctx, el, sourceOffset);
   if (located.outcome !== 'found') return located.outcome;
-  let written = false;
+  let outcome: EmbedHeightWriteOutcome = 'no-match';
   await app.vault.process(note, (doc) => {
     const offset = resolveCurrentOffset(doc, located.value);
     if (offset === null) return doc;
-    written = true;
-    return upsertViewportHeightComment(doc, lineAtOffset(doc, offset), height);
+    const updated = upsertViewportHeightComment(doc, lineAtOffset(doc, offset), height);
+    if (updated === null) {
+      // Table row / list-item line: inserting a comment there would corrupt
+      // the note's structure. Skip the write rather than damage the note.
+      outcome = 'unsupported';
+      return doc;
+    }
+    outcome = 'written';
+    return updated;
   });
-  return written ? 'written' : 'no-match';
+  return outcome;
 }
 
+/**
+ * Resolve which embed insertion in the note this render belongs to. Only
+ * reliable signals are used, in order: the Live Preview source offset (from
+ * the CodeMirror DOM position), the Reading-view section range, and finally a
+ * single unambiguous candidate. When several identical embeds remain, the
+ * result is 'ambiguous' and the caller must not write — a DOM-occurrence
+ * index is NOT used as a tiebreaker, because virtualized rendering (Reading
+ * view unloads offscreen sections) makes it point at the wrong insertion.
+ */
 function locateEmbed(
   app: App,
   sourcePath: string,
@@ -73,10 +77,9 @@ function locateEmbed(
   doc: string,
   ctx?: MarkdownPostProcessorContext,
   el?: HTMLElement,
-  occurrence?: number,
   sourceOffset?: number,
 ): { outcome: 'found'; value: LocatedEmbed } | { outcome: 'no-match' | 'ambiguous' } {
-  const embeds = (app.metadataCache.getCache(sourcePath)?.embeds ?? []) as EmbedCacheItem[];
+  const embeds = app.metadataCache.getCache(sourcePath)?.embeds ?? [];
   const expectedSubpath = normalizeSubpath(subpath);
   const candidates = embeds.filter((item) => {
     const parsed = parseLinktext(sourceLinktext(item));
@@ -106,16 +109,12 @@ function locateEmbed(
     }
   }
 
-  if (occurrence !== undefined && candidates[occurrence]) {
-    return { outcome: 'found', value: { item: candidates[occurrence]!, allItems: embeds } };
-  }
-
   return candidates.length === 1
     ? { outcome: 'found', value: { item: candidates[0]!, allItems: embeds } }
     : { outcome: 'ambiguous' };
 }
 
-function sourceLinktext(item: EmbedCacheItem): string {
+function sourceLinktext(item: EmbedCache): string {
   const match = /^!\[\[([\s\S]*?)\]\]$/.exec(item.original.trim());
   if (!match) return item.link;
   return match[1]!.split('|', 1)[0]!.trim();

--- a/src/preview/interactiveMount.ts
+++ b/src/preview/interactiveMount.ts
@@ -1,0 +1,97 @@
+import {
+  InteractiveViewerController,
+  type BindSvgOptions,
+} from './interactiveViewer';
+
+export interface InteractiveMountSpec {
+  /** Re-resolved at interaction time so settings changes affect existing previews. */
+  isEnabled: () => boolean;
+  /** Persisted height already read by the caller (interactive-at-render path). */
+  initialHeight?: number;
+  /**
+   * Fetches the height persisted in the note when the controller is first
+   * constructed lazily (the click action was switched to Interactive viewer
+   * after this preview rendered, so the caller never pre-read it).
+   */
+  loadPersistedHeight?: () => Promise<number | null>;
+  onHeightCommit?: (height: number) => void;
+  onEdit?: () => void;
+  /** Hook the freshly constructed controller into the caller's lifecycle. */
+  onController?: (controller: InteractiveViewerController) => void;
+}
+
+export interface InteractiveMountHandle {
+  /** Null until the click action first resolves to the interactive viewer. */
+  readonly controller: InteractiveViewerController | null;
+  bindSvg(svg: SVGSVGElement | null, opts?: BindSvgOptions): void;
+  dispose(): void;
+}
+
+/**
+ * Mount the interactive viewer on a rendered preview.
+ *
+ * When the click action already resolves to the interactive viewer the
+ * controller is constructed immediately (so a persisted height shapes the
+ * first paint). In every other mode nothing is constructed — a controller
+ * carries five document/window-level listeners plus `user-select: none`
+ * styling, which previews that never use the viewer should not pay for.
+ * Instead a single root-scoped click listener waits: if the user switches the
+ * setting to Interactive viewer later, the first click on the preview
+ * constructs the controller, applies the note's persisted height, and
+ * activates it — matching the eager behavior without the standing cost.
+ */
+export function mountInteractiveViewer(
+  root: HTMLElement,
+  preview: HTMLElement,
+  spec: InteractiveMountSpec,
+): InteractiveMountHandle {
+  let controller: InteractiveViewerController | null = null;
+  let disposed = false;
+
+  const construct = (): InteractiveViewerController => {
+    const built = new InteractiveViewerController(root, preview, {
+      isEnabled: spec.isEnabled,
+      initialHeight: spec.initialHeight,
+      onHeightCommit: spec.onHeightCommit,
+      onEdit: spec.onEdit,
+    });
+    controller = built;
+    spec.onController?.(built);
+    built.bindSvg(preview.querySelector('svg'));
+    return built;
+  };
+
+  const onLazyActivateClick = (event: MouseEvent): void => {
+    if (disposed || controller || !spec.isEnabled()) return;
+    const target = event.target as Node | null;
+    if (!target || typeof target.nodeType !== 'number' || !preview.contains(target)) return;
+    root.removeEventListener('click', onLazyActivateClick);
+    const built = construct();
+    built.activate();
+    if (spec.loadPersistedHeight) {
+      spec.loadPersistedHeight().then((height) => {
+        if (height !== null) built.applyPersistedHeight(height);
+      }).catch(() => { /* keep the automatic height */ });
+    }
+  };
+
+  if (spec.isEnabled()) {
+    construct();
+  } else {
+    root.addEventListener('click', onLazyActivateClick);
+  }
+
+  return {
+    get controller() { return controller; },
+    bindSvg(svg, opts) {
+      controller?.bindSvg(svg, opts);
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      root.removeEventListener('click', onLazyActivateClick);
+      controller?.dispose();
+      controller = null;
+    },
+  };
+}

--- a/src/preview/interactiveMount.ts
+++ b/src/preview/interactiveMount.ts
@@ -16,8 +16,6 @@ export interface InteractiveMountSpec {
   loadPersistedHeight?: () => Promise<number | null>;
   onHeightCommit?: (height: number) => void;
   onEdit?: () => void;
-  /** Hook the freshly constructed controller into the caller's lifecycle. */
-  onController?: (controller: InteractiveViewerController) => void;
 }
 
 export interface InteractiveMountHandle {
@@ -35,10 +33,11 @@ export interface InteractiveMountHandle {
  * first paint). In every other mode nothing is constructed — a controller
  * carries five document/window-level listeners plus `user-select: none`
  * styling, which previews that never use the viewer should not pay for.
- * Instead a single root-scoped click listener waits: if the user switches the
- * setting to Interactive viewer later, the first click on the preview
- * constructs the controller, applies the note's persisted height, and
- * activates it — matching the eager behavior without the standing cost.
+ * Instead a pair of root-scoped click/pointerdown listeners waits: if the
+ * user switches the setting to Interactive viewer later, the first click or
+ * drag-start on the preview constructs the controller, applies the note's
+ * persisted height, and activates it — matching the eager behavior without
+ * the standing cost.
  */
 export function mountInteractiveViewer(
   root: HTMLElement,
@@ -56,17 +55,24 @@ export function mountInteractiveViewer(
       onEdit: spec.onEdit,
     });
     controller = built;
-    spec.onController?.(built);
     built.bindSvg(preview.querySelector('svg'));
     return built;
   };
 
-  const onLazyActivateClick = (event: MouseEvent): void => {
+  const removeLazyListeners = (): void => {
+    root.removeEventListener('click', onLazyActivate);
+    root.removeEventListener('pointerdown', onLazyPointerDown);
+  };
+
+  const tryLazyActivate = (event: Event): void => {
     if (disposed || controller || !spec.isEnabled()) return;
     const target = event.target as Node | null;
     if (!target || typeof target.nodeType !== 'number' || !preview.contains(target)) return;
-    root.removeEventListener('click', onLazyActivateClick);
+    // Nothing to view yet (a deferred render): keep the listeners armed
+    // instead of consuming them on a construction that cannot succeed.
+    if (!preview.querySelector('svg')) return;
     const built = construct();
+    removeLazyListeners();
     built.activate();
     if (spec.loadPersistedHeight) {
       spec.loadPersistedHeight().then((height) => {
@@ -75,10 +81,22 @@ export function mountInteractiveViewer(
     }
   };
 
+  const onLazyActivate = (event: MouseEvent): void => {
+    tryLazyActivate(event);
+  };
+
+  // Eager mounts also activate on pointerdown (onPanStart) — a drag that
+  // starts on the preview must behave the same when the mount was lazy.
+  const onLazyPointerDown = (event: PointerEvent): void => {
+    if (event.button !== 0) return;
+    tryLazyActivate(event);
+  };
+
   if (spec.isEnabled()) {
     construct();
   } else {
-    root.addEventListener('click', onLazyActivateClick);
+    root.addEventListener('click', onLazyActivate);
+    root.addEventListener('pointerdown', onLazyPointerDown);
   }
 
   return {
@@ -89,7 +107,7 @@ export function mountInteractiveViewer(
     dispose() {
       if (disposed) return;
       disposed = true;
-      root.removeEventListener('click', onLazyActivateClick);
+      removeLazyListeners();
       controller?.dispose();
       controller = null;
     },

--- a/src/preview/interactiveViewer.ts
+++ b/src/preview/interactiveViewer.ts
@@ -21,9 +21,22 @@ interface ViewBox {
   height: number;
 }
 
-const ZOOM_STEP = 1.02;
+/** Rendered content rectangle in client coordinates (letterbox-aware). */
+interface ContentRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** Fine-grained multiplicative step per wheel notch. */
+const WHEEL_ZOOM_STEP = 1.02;
+/** Coarser step for the discrete toolbar buttons — 2% per click is imperceptible. */
+const BUTTON_ZOOM_STEP = 1.25;
 const MAX_SCALE = 8;
 const SCALE_EPSILON = 0.0001;
+/** Pointer travel (px) below which a resize gesture is a click, not a resize. */
+const RESIZE_COMMIT_THRESHOLD = 2;
 
 /**
  * Minimal interactive-viewer lifecycle and activation shell.
@@ -51,6 +64,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   private manuallyResized = false;
   private resizeStartY = 0;
   private resizeStartHeight = 0;
+  private resizeMoved = false;
   private viewportHeight = 0;
   private panStartX = 0;
   private panStartY = 0;
@@ -69,16 +83,14 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.root.addEventListener('click', this.onRootClick);
     this.preview.addEventListener('wheel', this.onWheel, { passive: false });
     this.preview.addEventListener('pointerdown', this.onPanStart);
-    this.doc.addEventListener('click', this.onDocumentClick);
-    this.doc.addEventListener('keydown', this.onDocumentKeydown);
-    this.doc.addEventListener('fullscreenchange', this.onFullscreenChange);
-    this.doc.defaultView?.addEventListener('resize', this.onWindowResize);
+    this.addDocumentListeners(this.doc);
   }
 
   get isActive(): boolean { return this.active; }
 
   applyPersistedHeight(height: number): void {
     if (this.disposed || this.opts.isEnabled?.() === false) return;
+    this.rebindIfDocumentChanged();
     const next = clamp(height, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
     this.opts.initialHeight = next;
     this.manuallyResized = true;
@@ -92,6 +104,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   }
 
   bindSvg(svg: SVGSVGElement | null, opts: BindSvgOptions = {}): void {
+    this.rebindIfDocumentChanged();
     const preservedHeight = opts.preserveViewportHeight && this.viewportInitialized
       ? this.viewportHeight
       : null;
@@ -120,6 +133,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
 
   activate(): void {
     if (this.disposed || this.opts.isEnabled?.() === false || !this.svg) return;
+    this.rebindIfDocumentChanged();
     this.initializeViewport();
     this.active = true;
     this.root.classList.add('drawio-interactive-active');
@@ -138,21 +152,25 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    // Being torn down while fullscreen (e.g. the note re-renders) would leave
+    // the pane stuck fullscreen with no exit control — reconcile first.
+    if (this.doc.fullscreenElement === this.root && typeof this.doc.exitFullscreen === 'function') {
+      try {
+        void this.doc.exitFullscreen().catch(() => { /* host is already leaving */ });
+      } catch { /* host denies fullscreen control */ }
+    }
     this.deactivate();
     this.root.classList.remove('drawio-interactive');
     this.root.classList.remove('drawio-interactive-fullscreen');
     this.root.removeEventListener('click', this.onRootClick);
     this.preview.removeEventListener('wheel', this.onWheel);
     this.preview.removeEventListener('pointerdown', this.onPanStart);
-    this.doc.removeEventListener('click', this.onDocumentClick);
-    this.doc.removeEventListener('keydown', this.onDocumentKeydown);
-    this.doc.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    this.removeDocumentListeners(this.doc);
     this.doc.removeEventListener('pointermove', this.onResizeMove);
     this.doc.removeEventListener('pointerup', this.onResizeEnd);
     this.doc.removeEventListener('pointercancel', this.onResizeEnd);
     this.doc.removeEventListener('pointermove', this.onPanMove);
     this.doc.removeEventListener('pointerup', this.onPanEnd);
-    this.doc.defaultView?.removeEventListener('resize', this.onWindowResize);
     this.cancelFrame();
     this.toolbar.remove();
     this.resizeHandle.remove();
@@ -168,11 +186,43 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.dispose();
   }
 
+  private addDocumentListeners(doc: Document): void {
+    // Capture phase for click-outside: content click handlers (embeds, other
+    // plugins) may stopPropagation during bubbling, which must not leave a
+    // second viewer stuck active.
+    doc.addEventListener('click', this.onDocumentClick, true);
+    doc.addEventListener('keydown', this.onDocumentKeydown);
+    doc.addEventListener('fullscreenchange', this.onFullscreenChange);
+    doc.defaultView?.addEventListener('resize', this.onWindowResize);
+  }
+
+  private removeDocumentListeners(doc: Document): void {
+    doc.removeEventListener('click', this.onDocumentClick, true);
+    doc.removeEventListener('keydown', this.onDocumentKeydown);
+    doc.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    doc.defaultView?.removeEventListener('resize', this.onWindowResize);
+  }
+
+  /**
+   * Obsidian adopts a pane's DOM into a popout window after mount; the
+   * document-level listeners must follow the root's current document or
+   * Escape, click-outside, drags, and fullscreen keep targeting the old
+   * window (same pattern as DrawioEditor.rebindIfWindowChanged). Checked at
+   * every element-bound entry point, since those listeners travel with the DOM.
+   */
+  private rebindIfDocumentChanged(): void {
+    const current = this.root.ownerDocument;
+    if (current === this.doc) return;
+    this.removeDocumentListeners(this.doc);
+    this.doc = current;
+    if (!this.disposed) this.addDocumentListeners(current);
+  }
+
   private createToolbar(): HTMLElement {
     const toolbar = this.root.createDiv({ cls: 'drawio-interactive-toolbar' });
     toolbar.setAttribute('aria-label', 'Interactive viewer controls');
-    this.zoomInButton = this.createButton(toolbar, '+', 'Zoom in', () => this.zoomBy(ZOOM_STEP));
-    this.zoomOutButton = this.createButton(toolbar, '−', 'Zoom out', () => this.zoomBy(1 / ZOOM_STEP));
+    this.zoomInButton = this.createButton(toolbar, '+', 'Zoom in', () => this.zoomBy(BUTTON_ZOOM_STEP));
+    this.zoomOutButton = this.createButton(toolbar, '−', 'Zoom out', () => this.zoomBy(1 / BUTTON_ZOOM_STEP));
     this.fitButton = this.createButton(toolbar, 'Fit', 'Fit diagram', () => this.fit());
     this.editButton = this.createButton(
       toolbar, 'Edit', 'Edit diagram', () => { void this.runEditAction(); },
@@ -188,7 +238,12 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   }
 
   private createResizeHandle(): HTMLElement {
-    const handle = this.root.createDiv({ cls: 'drawio-interactive-resize-handle' });
+    // Anchor the handle to the preview's own positioned wrapper when there is
+    // one (the read-only file view nests the preview inside a padded content
+    // element); positioning against the outer root would leave the handle
+    // offset from the viewport's real bottom edge by that padding.
+    const host = this.preview.parentElement ?? this.root;
+    const handle = host.createDiv({ cls: 'drawio-interactive-resize-handle' });
     handle.setAttribute('role', 'separator');
     handle.setAttribute('aria-label', 'Resize interactive viewer');
     handle.setAttribute('aria-orientation', 'horizontal');
@@ -246,15 +301,18 @@ export class InteractiveViewerController extends MarkdownRenderChild {
 
   private onWheel = (event: WheelEvent): void => {
     if (!this.active || event.deltaY === 0) return;
+    this.rebindIfDocumentChanged();
     event.preventDefault();
-    this.zoomBy(event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP, event.clientX, event.clientY);
+    this.zoomBy(event.deltaY < 0 ? WHEEL_ZOOM_STEP : 1 / WHEEL_ZOOM_STEP, event.clientX, event.clientY);
   };
 
   private onPanStart = (event: PointerEvent): void => {
+    if (event.button !== 0) return; // never let a right/middle press activate or pan
+    this.rebindIfDocumentChanged();
     if (!this.active) this.activate();
     const base = this.baseBox;
     const current = this.currentBox;
-    if (!this.active || event.button !== 0 || !base || !current) return;
+    if (!this.active || !base || !current) return;
     if (base.width / current.width <= 1 + SCALE_EPSILON) return;
     event.preventDefault();
     event.stopPropagation();
@@ -275,14 +333,20 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     const rect = svg.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) return;
     event.preventDefault();
+    // `preserveAspectRatio="meet"` letterboxes the content inside the client
+    // rect once the viewport aspect no longer matches the viewBox; pixel
+    // deltas convert to viewBox units through the rendered content scale,
+    // not the raw rect dimensions.
+    const scale = Math.min(rect.width / start.width, rect.height / start.height);
+    if (scale <= 0) return;
     this.currentBox = {
       x: clamp(
-        start.x - (event.clientX - this.panStartX) * start.width / rect.width,
+        start.x - (event.clientX - this.panStartX) / scale,
         base.x,
         base.x + base.width - start.width,
       ),
       y: clamp(
-        start.y - (event.clientY - this.panStartY) * start.height / rect.height,
+        start.y - (event.clientY - this.panStartY) / scale,
         base.y,
         base.y + base.height - start.height,
       ),
@@ -333,12 +397,13 @@ export class InteractiveViewerController extends MarkdownRenderChild {
 
   private onResizeStart = (event: PointerEvent): void => {
     if (!this.active) return;
+    this.rebindIfDocumentChanged();
     event.preventDefault();
     event.stopPropagation();
     this.resizeStartY = event.clientY;
     this.resizeStartHeight = parseFloat(this.preview.style.height)
       || this.preview.getBoundingClientRect().height;
-    this.manuallyResized = true;
+    this.resizeMoved = false;
     this.root.classList.add('drawio-interactive-resizing');
     this.doc.addEventListener('pointermove', this.onResizeMove);
     this.doc.addEventListener('pointerup', this.onResizeEnd);
@@ -351,7 +416,14 @@ export class InteractiveViewerController extends MarkdownRenderChild {
       MIN_VIEWPORT_HEIGHT,
       MAX_VIEWPORT_HEIGHT,
     );
-    this.setViewportHeight(height);
+    if (Math.abs(height - this.resizeStartHeight) >= RESIZE_COMMIT_THRESHOLD) {
+      this.resizeMoved = true;
+      this.manuallyResized = true;
+    }
+    // An explicit user height IS a viewport — initialize from it even when
+    // the automatic measurement was deferred (detached render).
+    if (this.svg) this.applyViewport(this.svg, height);
+    else this.setViewportHeight(height);
     this.fit();
   };
 
@@ -360,11 +432,14 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.doc.removeEventListener('pointermove', this.onResizeMove);
     this.doc.removeEventListener('pointerup', this.onResizeEnd);
     this.doc.removeEventListener('pointercancel', this.onResizeEnd);
+    // A plain click on the handle (zero drag) must not touch the note.
+    if (!this.resizeMoved) return;
+    this.resizeMoved = false;
     this.opts.onHeightCommit?.(Math.round(this.viewportHeight));
   };
 
   private onWindowResize = (): void => {
-    if (this.viewportInitialized && !this.manuallyResized) this.initializeViewport(true);
+    if (!this.manuallyResized) this.initializeViewport(true);
   };
 
   private initializeViewport(force = false): void {
@@ -373,16 +448,31 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     const svg = this.svg;
     const win = this.doc.defaultView;
     if (!base || !svg || !win) return;
+    if (this.opts.initialHeight !== undefined) {
+      this.applyViewport(svg, clamp(this.opts.initialHeight, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT));
+      return;
+    }
     const width = this.preview.getBoundingClientRect().width
-      || this.root.getBoundingClientRect().width
-      || base.width;
-    const proportionalHeight = width * base.height / base.width;
+      || this.root.getBoundingClientRect().width;
+    if (width <= 0) {
+      // Detached or hidden (code blocks and Reading-view sections render
+      // detached): measuring now would produce a bogus height. Stay
+      // uninitialized — activation and window resizes re-enter here once the
+      // element is laid out.
+      return;
+    }
     const availableHeight = Math.max(1, win.innerHeight);
+    const height = clamp(
+      Math.min(width * base.height / base.width, availableHeight),
+      MIN_VIEWPORT_HEIGHT,
+      MAX_VIEWPORT_HEIGHT,
+    );
+    this.applyViewport(svg, height);
+  }
+
+  private applyViewport(svg: SVGSVGElement, height: number): void {
     this.preview.classList.add('drawio-interactive-viewport');
     svg.classList.add('drawio-interactive-svg');
-    const height = this.opts.initialHeight === undefined
-      ? Math.min(proportionalHeight, availableHeight)
-      : clamp(this.opts.initialHeight, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
     this.setViewportHeight(height);
     this.viewportInitialized = true;
   }
@@ -403,13 +493,13 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     const nextScale = clamp(scale * factor, 1, MAX_SCALE);
     if (Math.abs(nextScale - scale) < SCALE_EPSILON) return;
 
-    const rect = svg.getBoundingClientRect();
-    const rx = clientX === undefined || rect.width <= 0
+    const content = this.contentRect(svg, current);
+    const rx = clientX === undefined || !content
       ? 0.5
-      : clamp((clientX - rect.left) / rect.width, 0, 1);
-    const ry = clientY === undefined || rect.height <= 0
+      : clamp((clientX - content.left) / content.width, 0, 1);
+    const ry = clientY === undefined || !content
       ? 0.5
-      : clamp((clientY - rect.top) / rect.height, 0, 1);
+      : clamp((clientY - content.top) / content.height, 0, 1);
     const anchorX = current.x + rx * current.width;
     const anchorY = current.y + ry * current.height;
     const width = base.width / nextScale;
@@ -423,6 +513,27 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     };
     this.updateControls();
     this.scheduleViewBoxWrite();
+  }
+
+  /**
+   * The client rectangle the viewBox content actually occupies. With the
+   * default `preserveAspectRatio` ("xMidYMid meet") the content is scaled
+   * uniformly and centered, leaving letterbox margins whenever the element's
+   * aspect differs from the viewBox's — mapping the cursor over the full
+   * client rect would drift the zoom anchor on every wheel step.
+   */
+  private contentRect(svg: SVGSVGElement, box: ViewBox): ContentRect | null {
+    const rect = svg.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    const scale = Math.min(rect.width / box.width, rect.height / box.height);
+    const width = box.width * scale;
+    const height = box.height * scale;
+    return {
+      left: rect.left + (rect.width - width) / 2,
+      top: rect.top + (rect.height - height) / 2,
+      width,
+      height,
+    };
   }
 
   private fit(): void {
@@ -462,10 +573,14 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.frame = null;
   }
 
-  /** Use the preview document's DOM realm so popout-window events are accepted. */
+  /**
+   * Duck-type the event target instead of an instanceof check against one
+   * realm's Node constructor — after a pane moves to a popout window, events
+   * arrive from a different realm and a realm-bound check drops them.
+   */
   private eventNode(event: Event): Node | null {
-    const NodeCtor = this.doc.defaultView?.Node;
-    return NodeCtor && event.target instanceof NodeCtor ? event.target : null;
+    const target = event.target as Node | null;
+    return target && typeof target.nodeType === 'number' ? target : null;
   }
 }
 

--- a/src/preview/interactiveViewer.ts
+++ b/src/preview/interactiveViewer.ts
@@ -69,6 +69,8 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   private panStartX = 0;
   private panStartY = 0;
   private panStartBox: ViewBox | null = null;
+  /** Watches a detached/hidden preview until layout gives it a real width. */
+  private measureObserver: ResizeObserver | null = null;
 
   constructor(
     private root: HTMLElement,
@@ -96,10 +98,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.manuallyResized = true;
     if (this.viewportInitialized && Math.abs(this.viewportHeight - next) < 0.5) return;
     if (!this.svg || !this.baseBox) return;
-    this.preview.classList.add('drawio-interactive-viewport');
-    this.svg.classList.add('drawio-interactive-svg');
-    this.setViewportHeight(next);
-    this.viewportInitialized = true;
+    this.applyViewport(this.svg, next);
     this.fit();
   }
 
@@ -122,10 +121,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.updateControls();
     if (this.opts.isEnabled?.() === false) return;
     if (preservedHeight !== null && svg && this.baseBox) {
-      this.preview.classList.add('drawio-interactive-viewport');
-      svg.classList.add('drawio-interactive-svg');
-      this.setViewportHeight(preservedHeight);
-      this.viewportInitialized = true;
+      this.applyViewport(svg, preservedHeight);
       return;
     }
     this.initializeViewport();
@@ -171,6 +167,7 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.doc.removeEventListener('pointercancel', this.onResizeEnd);
     this.doc.removeEventListener('pointermove', this.onPanMove);
     this.doc.removeEventListener('pointerup', this.onPanEnd);
+    this.disconnectMeasureObserver();
     this.cancelFrame();
     this.toolbar.remove();
     this.resizeHandle.remove();
@@ -215,7 +212,13 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     if (current === this.doc) return;
     this.removeDocumentListeners(this.doc);
     this.doc = current;
-    if (!this.disposed) this.addDocumentListeners(current);
+    if (this.disposed) return;
+    this.addDocumentListeners(current);
+    // A ResizeObserver belongs to one window; re-arm it from the new one.
+    if (this.measureObserver) {
+      this.disconnectMeasureObserver();
+      this.observeUntilMeasurable();
+    }
   }
 
   private createToolbar(): HTMLElement {
@@ -263,6 +266,10 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     button.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
+      // A pane can move into a popout without any prior rebinding interaction
+      // (e.g. the "Move to new window" command while the viewer is active) —
+      // and this handler's stopPropagation keeps onRootClick from rebinding.
+      this.rebindIfDocumentChanged();
       action();
     });
     return button;
@@ -411,15 +418,21 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   };
 
   private onResizeMove = (event: PointerEvent): void => {
+    // Judge the gesture by raw pointer travel, not by the clamped height
+    // delta (clamping an out-of-range start height would inflate a 1px
+    // wiggle past the threshold) — and until the drag engages, leave the
+    // viewport completely untouched so a click never disturbs the zoom.
+    if (!this.resizeMoved
+        && Math.abs(event.clientY - this.resizeStartY) < RESIZE_COMMIT_THRESHOLD) {
+      return;
+    }
+    this.resizeMoved = true;
+    this.manuallyResized = true;
     const height = clamp(
       this.resizeStartHeight + event.clientY - this.resizeStartY,
       MIN_VIEWPORT_HEIGHT,
       MAX_VIEWPORT_HEIGHT,
     );
-    if (Math.abs(height - this.resizeStartHeight) >= RESIZE_COMMIT_THRESHOLD) {
-      this.resizeMoved = true;
-      this.manuallyResized = true;
-    }
     // An explicit user height IS a viewport — initialize from it even when
     // the automatic measurement was deferred (detached render).
     if (this.svg) this.applyViewport(this.svg, height);
@@ -439,7 +452,10 @@ export class InteractiveViewerController extends MarkdownRenderChild {
   };
 
   private onWindowResize = (): void => {
-    if (!this.manuallyResized) this.initializeViewport(true);
+    // Same isEnabled gate as every other entry point: after the click action
+    // is switched away, a window resize must not re-apply the viewport.
+    if (this.manuallyResized || this.opts.isEnabled?.() === false) return;
+    this.initializeViewport(true);
   };
 
   private initializeViewport(force = false): void {
@@ -456,9 +472,11 @@ export class InteractiveViewerController extends MarkdownRenderChild {
       || this.root.getBoundingClientRect().width;
     if (width <= 0) {
       // Detached or hidden (code blocks and Reading-view sections render
-      // detached): measuring now would produce a bogus height. Stay
-      // uninitialized — activation and window resizes re-enter here once the
-      // element is laid out.
+      // detached): measuring now would produce a bogus height. Watch for the
+      // first real layout instead — otherwise a tall diagram renders at full
+      // height until the user clicks or resizes the OS window (Obsidian pane
+      // drags don't fire window resize, and PDF export never clicks).
+      this.observeUntilMeasurable();
       return;
     }
     const availableHeight = Math.max(1, win.innerHeight);
@@ -470,7 +488,30 @@ export class InteractiveViewerController extends MarkdownRenderChild {
     this.applyViewport(svg, height);
   }
 
+  private observeUntilMeasurable(): void {
+    const win = this.doc.defaultView;
+    if (!win || this.measureObserver || typeof win.ResizeObserver !== 'function') return;
+    this.measureObserver = new win.ResizeObserver(() => {
+      if (this.disposed || this.viewportInitialized || this.manuallyResized
+          || this.opts.isEnabled?.() === false) {
+        this.disconnectMeasureObserver();
+        return;
+      }
+      const width = this.preview.getBoundingClientRect().width
+        || this.root.getBoundingClientRect().width;
+      if (width <= 0) return;
+      this.initializeViewport();
+    });
+    this.measureObserver.observe(this.preview);
+  }
+
+  private disconnectMeasureObserver(): void {
+    this.measureObserver?.disconnect();
+    this.measureObserver = null;
+  }
+
   private applyViewport(svg: SVGSVGElement, height: number): void {
+    this.disconnectMeasureObserver();
     this.preview.classList.add('drawio-interactive-viewport');
     svg.classList.add('drawio-interactive-svg');
     this.setViewportHeight(height);

--- a/src/preview/sectionLifecycle.ts
+++ b/src/preview/sectionLifecycle.ts
@@ -1,0 +1,39 @@
+import { MarkdownRenderChild } from 'obsidian';
+
+/**
+ * Tracks whether the markdown section that owns a rendered preview is alive.
+ *
+ * Register one with `ctx.addChild` synchronously — before any awaits — then
+ * queue lifecycle-sensitive work through {@link whenReady}. Obsidian loads a
+ * child of a live section immediately (or when the section itself loads
+ * later), but a child added to an already-torn-down section is stored and
+ * never loaded: queued work then simply never runs, so nothing that needs a
+ * later teardown is ever created. This also covers the ordering race where
+ * async rendering finishes before the section's load is dispatched — the
+ * work is queued and runs from `onload` instead of being silently skipped.
+ */
+export class SectionLifecycle extends MarkdownRenderChild {
+  private loadedOnce = false;
+  private torndown = false;
+  private readyCallbacks: Array<() => void> = [];
+
+  onload(): void {
+    this.loadedOnce = true;
+    for (const cb of this.readyCallbacks.splice(0)) cb();
+  }
+
+  onunload(): void {
+    this.torndown = true;
+    this.readyCallbacks.length = 0;
+  }
+
+  /**
+   * Runs `cb` once the section is loaded (immediately when it already is);
+   * drops it when the section is — or later gets — torn down first.
+   */
+  whenReady(cb: () => void): void {
+    if (this.torndown) return;
+    if (this.loadedOnce) cb();
+    else this.readyCallbacks.push(cb);
+  }
+}

--- a/src/preview/viewportHeight.ts
+++ b/src/preview/viewportHeight.ts
@@ -12,6 +12,12 @@ const ANY_COMMENT_RE = /^[\s>]*<!--\s*drawio-viewer\s*:/;
 const LINE_PREFIX_RE = /^[ \t]*(?:>[ \t]*)*/;
 /** Bullet / ordered-list markers — inserting a bare comment line above these restructures the list. */
 const LIST_MARKER_RE = /^(?:[-*+]|\d{1,9}[.)])\s/;
+/** Wikilink spans, whose `|` alias separators are not table delimiters. */
+const WIKILINK_RE = /!?\[\[[^\]]*\]\]/g;
+/** Escaped pipes are cell content even inside tables, never delimiters. */
+const ESCAPED_PIPE_RE = /\\\|/g;
+/** A callout/blockquote title line (`[!note] …`) — its marker must stay on the quote's first line. */
+const CALLOUT_TITLE_RE = /^\[!/;
 
 export function parseViewportHeightComment(line: string | undefined): number | null {
   const raw = COMMENT_RE.exec(line ?? '')?.[1];
@@ -29,9 +35,9 @@ export function parseViewportHeightComment(line: string | undefined): number | n
  * The inserted line reproduces the anchor line's blockquote/indentation
  * prefix so a diagram inside a callout keeps its callout intact. When the
  * anchor sits where a bare inserted line would corrupt the surrounding
- * structure — a table row or directly on a list-item marker — the write is
- * refused (`null`): not persisting the height is always preferable to
- * damaging the note.
+ * structure — a table row (bordered or borderless), a list-item marker
+ * line, or a callout title line — the write is refused (`null`): not
+ * persisting the height is always preferable to damaging the note.
  */
 export function upsertViewportHeightComment(
   doc: string,
@@ -41,17 +47,43 @@ export function upsertViewportHeightComment(
   const lines = doc.split('\n');
   const anchor = stripCr(lines[blockStart] ?? '');
   const prefix = LINE_PREFIX_RE.exec(anchor)?.[0] ?? '';
-  const comment = `${prefix}<!-- drawio-viewer: height=${clampHeight(height)} -->`;
   const previous = lines[blockStart - 1];
   if (blockStart > 0 && ANY_COMMENT_RE.test(stripCr(previous ?? ''))) {
-    // Updating the existing comment line never changes the note's structure.
-    lines[blockStart - 1] = comment + trailingCr(previous ?? '');
+    // Updating the existing comment line never changes the note's structure —
+    // and must keep the line's OWN prefix: the anchor may since have been
+    // de-quoted (or re-quoted) independently of the comment above it.
+    const prevPrefix = LINE_PREFIX_RE.exec(stripCr(previous ?? ''))?.[0] ?? '';
+    lines[blockStart - 1] =
+      `${prevPrefix}<!-- drawio-viewer: height=${clampHeight(height)} -->${trailingCr(previous ?? '')}`;
     return lines.join('\n');
   }
   const rest = anchor.slice(prefix.length);
-  if (rest.startsWith('|') || LIST_MARKER_RE.test(rest)) return null;
-  lines.splice(blockStart, 0, comment + trailingCr(lines[blockStart] ?? ''));
+  if (!canInsertAbove(prefix, rest)) return null;
+  // Match the file's dominant line ending, not the anchor's own: the last
+  // line of a CRLF note has no trailing CR, but the inserted line (which is
+  // never file-final) still needs one.
+  const eol = doc.includes('\r\n') ? '\r' : '';
+  lines.splice(
+    blockStart, 0,
+    `${prefix}<!-- drawio-viewer: height=${clampHeight(height)} -->${eol}`,
+  );
   return lines.join('\n');
+}
+
+/**
+ * Whether a bare comment line can be inserted above the anchor without
+ * restructuring the surrounding Markdown. Refused for list-item marker
+ * lines, callout title lines (the `[!type]` marker must stay on the quote's
+ * first line), and anything carrying a GFM table delimiter — including
+ * borderless rows (`a | b`), which is why any unescaped pipe outside a
+ * wikilink counts, not just a leading one.
+ */
+function canInsertAbove(prefix: string, rest: string): boolean {
+  if (LIST_MARKER_RE.test(rest)) return false;
+  if (prefix.includes('>') && CALLOUT_TITLE_RE.test(rest)) return false;
+  const withoutLinks = rest.replace(WIKILINK_RE, '');
+  const withoutEscapes = withoutLinks.replace(ESCAPED_PIPE_RE, '');
+  return !withoutEscapes.includes('|');
 }
 
 export async function readCodeBlockViewportHeight(

--- a/src/preview/viewportHeight.ts
+++ b/src/preview/viewportHeight.ts
@@ -1,12 +1,17 @@
 import { App, MarkdownPostProcessorContext, TFile } from 'obsidian';
+import { locateAllDrawioBlocks } from '../codeblock/locateBlock';
 
 export const MIN_VIEWPORT_HEIGHT = 80;
 export const MAX_VIEWPORT_HEIGHT = 4000;
 
-const COMMENT_RE = /^\s*<!--\s*drawio-viewer:\s*height=(\d+)\s*-->\s*$/;
-const ANY_COMMENT_RE = /^\s*<!--\s*drawio-viewer\s*:/;
-const OPEN_RE = /^\s*(```+|~~~+)\s*drawio\s*$/;
-const CLOSE_RE = /^\s*(```+|~~~+)\s*$/;
+// A `[\s>]*` prefix accepts the comment inside callouts/blockquotes (`> `,
+// nested `> > `), where the writer below reproduces the quote markers.
+const COMMENT_RE = /^[\s>]*<!--\s*drawio-viewer:\s*height=(\d+)\s*-->\s*$/;
+const ANY_COMMENT_RE = /^[\s>]*<!--\s*drawio-viewer\s*:/;
+/** Leading indentation and blockquote markers of a Markdown line. */
+const LINE_PREFIX_RE = /^[ \t]*(?:>[ \t]*)*/;
+/** Bullet / ordered-list markers — inserting a bare comment line above these restructures the list. */
+const LIST_MARKER_RE = /^(?:[-*+]|\d{1,9}[.)])\s/;
 
 export function parseViewportHeightComment(line: string | undefined): number | null {
   const raw = COMMENT_RE.exec(line ?? '')?.[1];
@@ -17,16 +22,35 @@ export function parseViewportHeightComment(line: string | undefined): number | n
     : null;
 }
 
-export function upsertViewportHeightComment(doc: string, blockStart: number, height: number): string {
+/**
+ * Insert (or update in place) the `<!-- drawio-viewer: height=N -->` line
+ * right above the block/embed starting at `blockStart`.
+ *
+ * The inserted line reproduces the anchor line's blockquote/indentation
+ * prefix so a diagram inside a callout keeps its callout intact. When the
+ * anchor sits where a bare inserted line would corrupt the surrounding
+ * structure — a table row or directly on a list-item marker — the write is
+ * refused (`null`): not persisting the height is always preferable to
+ * damaging the note.
+ */
+export function upsertViewportHeightComment(
+  doc: string,
+  blockStart: number,
+  height: number,
+): string | null {
   const lines = doc.split('\n');
-  const opening = lines[blockStart] ?? '';
-  const indent = /^\s*/.exec(opening)?.[0] ?? '';
-  const comment = `${indent}<!-- drawio-viewer: height=${clampHeight(height)} -->`;
-  if (blockStart > 0 && ANY_COMMENT_RE.test(lines[blockStart - 1] ?? '')) {
-    lines[blockStart - 1] = comment;
-  } else {
-    lines.splice(blockStart, 0, comment);
+  const anchor = stripCr(lines[blockStart] ?? '');
+  const prefix = LINE_PREFIX_RE.exec(anchor)?.[0] ?? '';
+  const comment = `${prefix}<!-- drawio-viewer: height=${clampHeight(height)} -->`;
+  const previous = lines[blockStart - 1];
+  if (blockStart > 0 && ANY_COMMENT_RE.test(stripCr(previous ?? ''))) {
+    // Updating the existing comment line never changes the note's structure.
+    lines[blockStart - 1] = comment + trailingCr(previous ?? '');
+    return lines.join('\n');
   }
+  const rest = anchor.slice(prefix.length);
+  if (rest.startsWith('|') || LIST_MARKER_RE.test(rest)) return null;
+  lines.splice(blockStart, 0, comment + trailingCr(lines[blockStart] ?? ''));
   return lines.join('\n');
 }
 
@@ -56,8 +80,10 @@ export async function writeCodeBlockViewportHeight(
   await app.vault.process(file, (doc) => {
     const start = resolveBlockStart(doc, ctx, el, source);
     if (start === null) return doc;
+    const updated = upsertViewportHeightComment(doc, start, height);
+    if (updated === null) return doc;
     changed = true;
-    return upsertViewportHeightComment(doc, start, height);
+    return updated;
   });
   return changed;
 }
@@ -69,29 +95,19 @@ function resolveBlockStart(
   source: string,
 ): number | null {
   const lines = doc.split('\n');
-  const getInfo = (ctx as unknown as {
-    getSectionInfo?: (target: HTMLElement) => { lineStart: number; lineEnd: number } | null;
-  }).getSectionInfo;
-  const info = getInfo?.call(ctx, el);
-  if (info && blockMatches(lines, info.lineStart, info.lineEnd, source)) return info.lineStart;
-
-  const matches: number[] = [];
-  for (let start = 0; start < lines.length; start += 1) {
-    if (!OPEN_RE.test(lines[start] ?? '')) continue;
-    for (let end = start + 1; end < lines.length; end += 1) {
-      if (!CLOSE_RE.test(lines[end] ?? '')) continue;
-      if (blockMatches(lines, start, end, source)) matches.push(start);
-      start = end;
-      break;
-    }
-  }
-  return matches.length === 1 ? matches[0]! : null;
+  const matches = locateAllDrawioBlocks(lines, source);
+  const info = ctx.getSectionInfo(el);
+  if (info && matches.some((match) => match.start === info.lineStart)) return info.lineStart;
+  return matches.length === 1 ? matches[0]!.start : null;
 }
 
-function blockMatches(lines: string[], start: number, end: number, source: string): boolean {
-  return OPEN_RE.test(lines[start] ?? '')
-    && CLOSE_RE.test(lines[end] ?? '')
-    && lines.slice(start + 1, end).join('\n').trim() === source.trim();
+function stripCr(line: string): string {
+  return line.endsWith('\r') ? line.slice(0, -1) : line;
+}
+
+/** The CR to give an inserted line so CRLF notes stay uniformly CRLF. */
+function trailingCr(neighborLine: string): string {
+  return neighborLine.endsWith('\r') ? '\r' : '';
 }
 
 function clampHeight(height: number): number {

--- a/tests/codeBlockEdit.test.ts
+++ b/tests/codeBlockEdit.test.ts
@@ -28,4 +28,10 @@ describe('replaceCodeBlockBody', () => {
     const out = replaceCodeBlockBody(doc, 0, 2, 'A2');
     expect(out).toBe(['```drawio', 'A2', '```', ''].join(NL));
   });
+
+  it('writes CRLF body lines into a CRLF note instead of mixing line endings', () => {
+    const doc = 'pre\r\n```drawio\r\nOLD1\r\nOLD2\r\n```\r\npost';
+    const out = replaceCodeBlockBody(doc, 1, 4, 'NEW1\nNEW2');
+    expect(out).toBe('pre\r\n```drawio\r\nNEW1\r\nNEW2\r\n```\r\npost');
+  });
 });

--- a/tests/drawioCodeBlockMobile.test.ts
+++ b/tests/drawioCodeBlockMobile.test.ts
@@ -37,9 +37,11 @@ function fakePlugin(
   };
   return {
     plugin: raw as unknown as DrawioPlugin,
+    // Load added children the way Obsidian's real ctx.addChild does for a
+    // live section — the interactive mount is queued on that load.
     run: async (source: string, el: HTMLElement, ctx: unknown) => processor!(source, el, {
       ...(ctx as object),
-      addChild: vi.fn(),
+      addChild: vi.fn((child: unknown) => { (child as { load?: () => void }).load?.(); }),
     }),
   };
 }
@@ -200,6 +202,60 @@ describe('drawio code block — mobile click behavior', () => {
     expect(wrapper.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
     await new Promise((resolve) => { window.setTimeout(resolve, 0); });
     expect(preview.style.height).toBe('333px');
+  });
+
+  it('never mounts the controller when the owning section is already torn down', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin } = fakePlugin(vi.fn(), 'interactive');
+    let processor: ((s: string, e: HTMLElement, c: unknown) => void | Promise<void>) | undefined;
+    (plugin as unknown as {
+      registerMarkdownCodeBlockProcessor: (lang: string, cb: Processor) => void;
+    }).registerMarkdownCodeBlockProcessor = (_lang, cb) => { processor = cb; };
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    // addChild stores the child but never loads it — exactly what Obsidian
+    // does when the section was unloaded while the processor awaited.
+    await processor!(XML, el, { sourcePath: 'note.md', addChild: vi.fn() });
+    const added = addSpy.mock.calls.filter((call) => call[0] === 'keydown').length;
+    addSpy.mockRestore();
+    expect(added).toBe(0);
+    expect(el.querySelector('.drawio-interactive-toolbar')).toBeNull();
+    expect(el.querySelector<HTMLElement>('.drawio-codeblock')!.classList.contains('drawio-interactive'))
+      .toBe(false);
+  });
+
+  it('constructs lazily on a drag start (pointerdown), matching eager activation', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run } = fakePlugin(vi.fn(), 'editor');
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md' });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    plugin.settings.previewClickAction = 'interactive';
+    wrapper.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+    expect(wrapper.classList.contains('drawio-interactive-active')).toBe(true);
+  });
+
+  it('keeps the lazy listeners armed while the preview has no SVG yet', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run } = fakePlugin(vi.fn(), 'editor');
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md' });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    const preview = wrapper.querySelector<HTMLElement>('.drawio-preview')!;
+    plugin.settings.previewClickAction = 'interactive';
+
+    const svg = preview.querySelector('svg')!;
+    svg.remove(); // deferred render: nothing to bind yet
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(wrapper.classList.contains('drawio-interactive')).toBe(false);
+
+    preview.appendChild(svg); // render finalized — the same listeners still work
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(wrapper.classList.contains('drawio-interactive-active')).toBe(true);
   });
 
   it('shows a Notice instead of opening the editor on mobile, with no edit hint', async () => {

--- a/tests/drawioCodeBlockMobile.test.ts
+++ b/tests/drawioCodeBlockMobile.test.ts
@@ -15,17 +15,21 @@ vi.mock('../src/preview/ViewerRenderer', () => ({
   },
 }));
 
-import { Platform } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { registerDrawioCodeBlock } from '../src/codeblock/DrawioCodeBlock';
 import type { PreviewClickAction } from '../src/settings';
 import type DrawioPlugin from '../src/main';
 
 type Processor = (source: string, el: HTMLElement, ctx: unknown) => void | Promise<void>;
 
-function fakePlugin(openEditor: DrawioPlugin['openEditor'], previewClickAction: PreviewClickAction = 'editor') {
+function fakePlugin(
+  openEditor: DrawioPlugin['openEditor'],
+  previewClickAction: PreviewClickAction = 'editor',
+  app: Record<string, unknown> = {},
+) {
   let processor: Processor | undefined;
   const raw = {
-    app: {},
+    app,
     settings: { previewClickAction, editButtonAction: 'editor' },
     previewOpts: () => ({ dark: false }),
     openEditor,
@@ -148,6 +152,54 @@ describe('drawio code block — mobile click behavior', () => {
     expect(preview.style.height).toBe(height);
     expect(wrapper.classList.contains('drawio-interactive-active')).toBe(false);
     expect(wrapper.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+  });
+
+  it('renders the diagram even when the stored-height read fails', async () => {
+    Platform.isDesktopApp = true;
+    const app = { vault: { getAbstractFileByPath: () => { throw new Error('metadata boom'); } } };
+    const { plugin, run } = fakePlugin(vi.fn(), 'interactive', app);
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md' });
+    expect(el.querySelector('.drawio-preview svg')).not.toBeNull();
+    expect(el.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+  });
+
+  it('constructs no interactive controller outside Interactive Viewer mode', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, run } = fakePlugin(vi.fn(), 'editor');
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md' });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    expect(wrapper.querySelector('.drawio-interactive-toolbar')).toBeNull();
+    expect(wrapper.classList.contains('drawio-interactive')).toBe(false);
+  });
+
+  it('activates lazily with the stored height after switching to Interactive viewer', async () => {
+    Platform.isDesktopApp = true;
+    const note = Object.assign(new TFile(), { path: 'note.md', basename: 'note' });
+    const doc = `<!-- drawio-viewer: height=333 -->\n\`\`\`drawio\n${XML}\n\`\`\``;
+    const app = {
+      vault: {
+        getAbstractFileByPath: (p: string) => (p === 'note.md' ? note : null),
+        cachedRead: () => Promise.resolve(doc),
+      },
+    };
+    const { plugin, run } = fakePlugin(vi.fn(), 'editor', app);
+    registerDrawioCodeBlock(plugin);
+    const el = document.createElement('div');
+    await run(XML, el, { sourcePath: 'note.md', getSectionInfo: () => null });
+    const wrapper = el.querySelector<HTMLElement>('.drawio-codeblock')!;
+    expect(wrapper.classList.contains('drawio-interactive')).toBe(false);
+
+    plugin.settings.previewClickAction = 'interactive';
+    const preview = wrapper.querySelector<HTMLElement>('.drawio-preview')!;
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(wrapper.classList.contains('drawio-interactive-active')).toBe(true);
+    expect(wrapper.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+    await new Promise((resolve) => { window.setTimeout(resolve, 0); });
+    expect(preview.style.height).toBe('333px');
   });
 
   it('shows a Notice instead of opening the editor on mobile, with no edit hint', async () => {

--- a/tests/drawioPreviewFileView.test.ts
+++ b/tests/drawioPreviewFileView.test.ts
@@ -131,6 +131,12 @@ describe('DrawioPreviewFileView', () => {
     view.setViewData(MULTI_PAGE_XML, true);
     const preview = view.contentEl.querySelector<HTMLElement>('.drawio-preview')!;
     preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    // Establish a viewport height by resizing (jsdom measures 0, so the
+    // automatic height stays deferred until a real layout or a manual resize).
+    const handle = view.contentEl.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 400 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 400 }));
     const height = preview.style.height;
     view.contentEl.querySelectorAll<HTMLButtonElement>('.drawio-page-control button')[1]!.click();
     const replacement = preview.querySelector('svg')!;

--- a/tests/embedInteractiveFallback.dom.test.ts
+++ b/tests/embedInteractiveFallback.dom.test.ts
@@ -86,4 +86,24 @@ describe('interactive embed fallback renderer', () => {
     expect(preview.style.height).toBe(height);
     expect(span.classList.contains('drawio-interactive-active')).toBe(false);
   });
+
+  it('mounts once the section load arrives, even after the async render finished', async () => {
+    const { processor } = harness();
+    const section = document.body.createDiv();
+    const span = section.createSpan({ cls: 'internal-embed' });
+    span.setAttribute('src', 'diagram.drawio');
+    // Obsidian stores the child now and dispatches its load later — e.g.
+    // when the render's awaits complete before the section's own load.
+    let pending: { load: () => void } | null = null;
+    const addChild = vi.fn((child: unknown) => { pending = child as { load: () => void }; });
+    processor()(section, { sourcePath: 'note.md', addChild });
+    await tick();
+    expect(span.classList.contains('drawio-interactive')).toBe(false);
+
+    pending!.load();
+    expect(span.classList.contains('drawio-interactive')).toBe(true);
+    span.querySelector<HTMLElement>('.drawio-preview')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(span.classList.contains('drawio-interactive-active')).toBe(true);
+  });
 });

--- a/tests/embedInteractiveFallback.dom.test.ts
+++ b/tests/embedInteractiveFallback.dom.test.ts
@@ -56,7 +56,10 @@ describe('interactive embed fallback renderer', () => {
     const section = document.body.createDiv();
     const span = section.createSpan({ cls: 'internal-embed' });
     span.setAttribute('src', 'diagram.drawio');
-    const addChild = vi.fn();
+    // Load added children the way Obsidian's real ctx.addChild does — the
+    // fallback renderer gates its interactive mount on the section lifecycle
+    // child actually being loaded.
+    const addChild = vi.fn((child: unknown) => { (child as { load?: () => void }).load?.(); });
     processor()(section, { sourcePath: 'note.md', addChild });
     await tick();
 
@@ -68,9 +71,19 @@ describe('interactive embed fallback renderer', () => {
     span.querySelector<HTMLButtonElement>('[aria-label="Edit diagram"]')!.click();
     expect(openEditor).toHaveBeenCalledTimes(1);
 
+    // Establish a viewport by resizing, then flip pages: the replacement SVG
+    // must be rebound while the manual height is preserved.
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = span.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 420 }));
+    const height = preview.style.height;
+
     span.querySelectorAll<HTMLButtonElement>('.drawio-page-control button')[1]!.click();
     expect(preview.querySelector<SVGSVGElement>('svg')!.dataset.page).toBe('1');
     expect(preview.querySelector('svg')!.classList.contains('drawio-interactive-svg')).toBe(true);
+    expect(preview.style.height).toBe(height);
     expect(span.classList.contains('drawio-interactive-active')).toBe(false);
   });
 });

--- a/tests/embedRendererMobile.test.ts
+++ b/tests/embedRendererMobile.test.ts
@@ -262,26 +262,78 @@ describe('drawio embed — mobile click behavior', () => {
     raf.mockRestore();
   });
 
-  it('passes the duplicate embed occurrence from the current Markdown surface', async () => {
+  it('does not construct the interactive controller outside Interactive Viewer mode', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create } = fakePlugin(vi.fn(), 'editor');
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    await create(containerEl, 'note.md').loadFile();
+    expect(containerEl.querySelector('.drawio-interactive-toolbar')).toBeNull();
+    expect(containerEl.classList.contains('drawio-interactive')).toBe(false);
+  });
+
+  it('does not leak the previous controller when renders overlap', async () => {
     Platform.isDesktopApp = true;
     const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
     registerDrawioEmbeds(plugin);
-    const surface = document.createElement('div');
-    surface.className = 'markdown-source-view';
-    const firstEl = surface.createDiv();
-    const secondEl = surface.createDiv();
-    await create(firstEl, 'note.md').loadFile();
-    await create(secondEl, 'note.md').loadFile();
+    const containerEl = document.createElement('div');
+    const embed = create(containerEl, 'note.md');
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    await Promise.all([embed.loadFile(), embed.loadFile()]);
+    const added = addSpy.mock.calls.filter((call) => call[0] === 'keydown').length;
+    const removed = removeSpy.mock.calls.filter((call) => call[0] === 'keydown').length;
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+    // Exactly one live controller: the superseded render must not have
+    // constructed (and leaked) a second set of document-level listeners.
+    expect(added - removed).toBe(1);
+    expect(containerEl.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+  });
 
-    secondEl.querySelector<HTMLElement>('.drawio-preview')!
-      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    const handle = secondEl.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
-    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 360 }));
-    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 520 }));
-    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 520 }));
+  it('coalesces bursts of note edits into one stored-height read', async () => {
+    Platform.isDesktopApp = true;
+    heightMetadata.read.mockResolvedValue(360);
+    const modifyHandlers: Array<(f: TFile) => void> = [];
+    const openWithDefaultApp = vi.fn();
+    const file = Object.assign(new TFile(), { path: 'diagram.drawio', basename: 'diagram' });
+    let creator: Creator | undefined;
+    const plugin = {
+      app: {
+        embedRegistry: { registerExtension: (_ext: string, c: Creator) => { creator = c; } },
+        vault: {
+          read: async () => XML,
+          on: (_event: string, cb: (f: TFile) => void) => { modifyHandlers.push(cb); return {}; },
+        },
+        openWithDefaultApp,
+      },
+      settings: { previewClickAction: 'interactive', editButtonAction: 'editor' },
+      previewOpts: () => ({ dark: false }),
+      openEditor: vi.fn(),
+      register: vi.fn(),
+    } as unknown as DrawioPlugin;
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    const embed = creator!({ containerEl, sourcePath: 'note.md' }, file, undefined) as unknown as {
+      loadFile: () => Promise<void>; load: () => void; unload: () => void;
+    };
+    embed.load(); // Obsidian loads the embed component, registering vault events
+    await embed.loadFile();
+    heightMetadata.read.mockClear();
 
-    expect(heightMetadata.write).toHaveBeenCalledTimes(1);
-    expect(heightMetadata.write.mock.calls[0]?.[7]).toBe(1);
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      const note = Object.assign(new TFile(), { path: 'note.md', basename: 'note' });
+      for (let burst = 0; burst < 5; burst += 1) {
+        for (const handler of modifyHandlers) handler(note);
+      }
+      expect(heightMetadata.read).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(300);
+      expect(heightMetadata.read).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      embed.unload();
+    }
   });
 
   it('shows a Notice instead of opening the editor on mobile, with no edit hint', async () => {

--- a/tests/embedRendererMobile.test.ts
+++ b/tests/embedRendererMobile.test.ts
@@ -15,7 +15,16 @@ vi.mock('../src/preview/ViewerRenderer', () => ({
   },
 }));
 const heightMetadata = vi.hoisted(() => ({
-  read: vi.fn((_app: unknown, _sourcePath: string) => Promise.resolve<number | null>(null)),
+  read: vi.fn((
+    _app: unknown,
+    _sourcePath: string,
+    _file?: unknown,
+    _subpath?: string,
+    _ctx?: unknown,
+    _el?: HTMLElement,
+    _sourceOffset?: number,
+    _occurrence?: number,
+  ) => Promise.resolve<number | null>(null)),
   write: vi.fn((
     _app: unknown,
     _sourcePath: string,
@@ -24,7 +33,7 @@ const heightMetadata = vi.hoisted(() => ({
     _height: number,
     _ctx?: unknown,
     _el?: HTMLElement,
-    _occurrence?: number,
+    _sourceOffset?: number,
   ) => Promise.resolve<'written'>('written')),
 }));
 vi.mock('../src/preview/embedViewportHeight', () => ({
@@ -289,6 +298,46 @@ describe('drawio embed — mobile click behavior', () => {
     // constructed (and leaked) a second set of document-level listeners.
     expect(added - removed).toBe(1);
     expect(containerEl.querySelectorAll('.drawio-interactive-toolbar')).toHaveLength(1);
+  });
+
+  it('renders nothing new after the embed component unloads mid-flight (pin/unload race)', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioEmbeds(plugin);
+    const containerEl = document.createElement('div');
+    const embed = create(containerEl, 'note.md') as unknown as {
+      loadFile: () => Promise<void>; load: () => void; unload: () => void;
+    };
+    embed.load();
+    await embed.loadFile();
+    expect(containerEl.querySelector('.drawio-interactive-toolbar')).not.toBeNull();
+
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    embed.unload();
+    // A caller holding an await (e.g. pin()) resumes and re-renders after
+    // the unload — this must be a no-op, not a fresh controller mount.
+    await embed.loadFile();
+    const added = addSpy.mock.calls.filter((call) => call[0] === 'keydown').length;
+    addSpy.mockRestore();
+    expect(added).toBe(0);
+    expect(containerEl.querySelector('.drawio-interactive-toolbar')).toBeNull();
+  });
+
+  it('passes the render-surface occurrence when reading duplicate embed heights', async () => {
+    Platform.isDesktopApp = true;
+    const { plugin, create } = fakePlugin(vi.fn(), 'interactive');
+    registerDrawioEmbeds(plugin);
+    const surface = document.createElement('div');
+    surface.className = 'markdown-preview-view';
+    const firstEl = surface.createDiv();
+    const secondEl = surface.createDiv();
+    await create(firstEl, 'note.md').loadFile();
+    await create(secondEl, 'note.md').loadFile();
+
+    // The initial stored-height READ carries the DOM occurrence so persisted
+    // heights of otherwise-identical Reading-view duplicates keep applying.
+    expect(heightMetadata.read.mock.calls[0]?.[7]).toBe(0);
+    expect(heightMetadata.read.mock.calls[1]?.[7]).toBe(1);
   });
 
   it('coalesces bursts of note edits into one stored-height read', async () => {

--- a/tests/embedViewportHeight.test.ts
+++ b/tests/embedViewportHeight.test.ts
@@ -97,6 +97,27 @@ describe('embed viewport height Markdown metadata', () => {
     expect(state.text).toBe(text);
   });
 
+  it('read falls back to the render-surface occurrence for identical duplicates', async () => {
+    // Reading view (registry path) has no ctx/el and no CodeMirror offset:
+    // without the occurrence hint, persisted heights of duplicate embeds
+    // would silently stop applying. Reads accept it; writes never do.
+    const embed = '![[diagram.drawio]]';
+    const text = `${embed}\n<!-- drawio-viewer: height=610 -->\n${embed}`;
+    const secondOffset = text.lastIndexOf(embed);
+    const { app, target } = harness(text, [
+      { link: 'diagram.drawio', original: embed, offset: 0 },
+      { link: 'diagram.drawio', original: embed, offset: secondOffset },
+    ]);
+    expect(await readEmbedViewportHeight(
+      app, 'note.md', target, undefined, undefined, undefined, undefined, 1,
+    )).toBe(610);
+    expect(await readEmbedViewportHeight(
+      app, 'note.md', target, undefined, undefined, undefined, undefined, 0,
+    )).toBeNull();
+    // Without any signal the read stays null instead of guessing.
+    expect(await readEmbedViewportHeight(app, 'note.md', target, undefined)).toBeNull();
+  });
+
   it('uses the Live Preview source offset to disambiguate duplicates', async () => {
     const embed = '![[diagram.drawio#Page-1]]';
     const text = `${embed}\nbetween\n${embed}`;

--- a/tests/embedViewportHeight.test.ts
+++ b/tests/embedViewportHeight.test.ts
@@ -80,7 +80,10 @@ describe('embed viewport height Markdown metadata', () => {
     expect(state.text).toBe(text);
   });
 
-  it('writes the selected occurrence when the render surface identifies it', async () => {
+  it('refuses duplicates when only an unreliable DOM position could disambiguate', async () => {
+    // Reading view virtualizes offscreen sections out of the DOM, so a
+    // DOM-occurrence index may point at the wrong insertion — with no other
+    // signal the write must be refused, never guessed.
     const embed = '![[diagram.drawio#Page-1]]';
     const text = `${embed}\nbetween\n${embed}`;
     const secondOffset = text.lastIndexOf(embed);
@@ -89,12 +92,12 @@ describe('embed viewport height Markdown metadata', () => {
       { link: 'diagram.drawio', original: embed, offset: secondOffset },
     ]);
     expect(await writeEmbedViewportHeight(
-      app, 'note.md', target, '#Page-1', 680, undefined, undefined, 1,
-    )).toBe('written');
-    expect(state.text).toBe(`${embed}\nbetween\n<!-- drawio-viewer: height=680 -->\n${embed}`);
+      app, 'note.md', target, '#Page-1', 680,
+    )).toBe('ambiguous');
+    expect(state.text).toBe(text);
   });
 
-  it('uses the Live Preview source offset before the DOM occurrence fallback', async () => {
+  it('uses the Live Preview source offset to disambiguate duplicates', async () => {
     const embed = '![[diagram.drawio#Page-1]]';
     const text = `${embed}\nbetween\n${embed}`;
     const secondOffset = text.lastIndexOf(embed);
@@ -104,9 +107,31 @@ describe('embed viewport height Markdown metadata', () => {
     ]);
     expect(await writeEmbedViewportHeight(
       app, 'note.md', target, '#Page-1', 720,
-      undefined, undefined, 0, secondOffset + 1,
+      undefined, undefined, secondOffset + 1,
     )).toBe('written');
     expect(state.text).toBe(`${embed}\nbetween\n<!-- drawio-viewer: height=720 -->\n${embed}`);
+  });
+
+  it('reproduces the callout prefix when the embed lives in a blockquote', async () => {
+    const embed = '![[diagram.drawio#Page-2]]';
+    const text = `> [!note] Diagram\n> ${embed}\nafter`;
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio#Page-2', original: embed, offset: text.indexOf(embed) },
+    ]);
+    expect(await writeEmbedViewportHeight(app, 'note.md', target, '#Page-2', 400)).toBe('written');
+    expect(state.text).toBe(
+      `> [!note] Diagram\n> <!-- drawio-viewer: height=400 -->\n> ${embed}\nafter`,
+    );
+  });
+
+  it('refuses to write when the embed sits inside a table row', async () => {
+    const embed = '![[diagram.drawio#Page-2]]';
+    const text = `| a | b |\n| - | - |\n| ${embed} | x |`;
+    const { app, target, state } = harness(text, [
+      { link: 'diagram.drawio#Page-2', original: embed, offset: text.indexOf(embed) },
+    ]);
+    expect(await writeEmbedViewportHeight(app, 'note.md', target, '#Page-2', 400)).toBe('unsupported');
+    expect(state.text).toBe(text);
   });
 
   it('uses section info to distinguish identical embeds in Reading view', async () => {

--- a/tests/interactiveViewer.dom.test.ts
+++ b/tests/interactiveViewer.dom.test.ts
@@ -396,6 +396,10 @@ describe('InteractiveViewerController walking skeleton', () => {
 
   it('keeps the current zoom when the persisted height is unchanged', () => {
     const { root, preview, svg, controller } = fixture();
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 300, right: 600, bottom: 300, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
     const frames: FrameRequestCallback[] = [];
     const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
       frames.push(callback);
@@ -440,6 +444,10 @@ describe('InteractiveViewerController walking skeleton', () => {
 
   it('rebinds a replacement page SVG, resets zoom, and preserves viewport height', () => {
     const { root, preview, svg, controller } = fixture();
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 200, height: 100, right: 200, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
     preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
 
@@ -525,6 +533,180 @@ describe('InteractiveViewerController walking skeleton', () => {
     expect(frames).toHaveLength(0);
     controller.dispose();
     raf.mockRestore();
+  });
+
+  it('does not commit a height when the resize handle is clicked without dragging', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const onHeightCommit = vi.fn();
+    const controller = new InteractiveViewerController(root, preview, {
+      initialHeight: 420,
+      onHeightCommit,
+    });
+    controller.bindSvg(svg);
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+
+    // Plain click: pointerdown + pointerup at the same position.
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 420 }));
+    expect(onHeightCommit).not.toHaveBeenCalled();
+
+    // A wiggle below the threshold is still a click, not a resize.
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 420 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 421 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 421 }));
+    expect(onHeightCommit).not.toHaveBeenCalled();
+
+    // An actual drag commits once.
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 421 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 500 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 500 }));
+    expect(onHeightCommit).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it('zooms by a perceptible step from the toolbar buttons', () => {
+    const { root, preview, svg, controller } = fixture();
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
+    frames.shift()!(0);
+    const [, , width, height] = svg.getAttribute('viewBox')!.split(' ').map(Number);
+    expect(width).toBeCloseTo(200 / 1.25);
+    expect(height).toBeCloseTo(100 / 1.25);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('anchors wheel zoom to the letterboxed content, not the raw client rect', () => {
+    const { preview, svg, controller } = fixture();
+    // Square viewport, 2:1 viewBox — "meet" letterboxes the content to the
+    // vertical middle band (y 50..150 in client coordinates).
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    preview.dispatchEvent(new WheelEvent('wheel', {
+      bubbles: true, cancelable: true, deltaY: -100, clientX: 100, clientY: 75,
+    }));
+    frames.shift()!(0);
+    const [x, y, width, height] = svg.getAttribute('viewBox')!.split(' ').map(Number);
+    // clientY=75 is 25% into the rendered content band (top 50, height 100):
+    // the content point (100, 25) must stay under the cursor.
+    expect(x! + 0.5 * width!).toBeCloseTo(100);
+    expect(y! + 0.25 * height!).toBeCloseTo(25);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('defers automatic height while detached and initializes on activation', () => {
+    const { root, preview, svg, controller } = fixture();
+    // jsdom reports zero-size rects — exactly what a detached code-block or
+    // Reading-view section measures. No bogus height may be applied from that.
+    expect(preview.style.height).toBe('');
+    expect(preview.classList.contains('drawio-interactive-viewport')).toBe(false);
+    expect(svg.classList.contains('drawio-interactive-svg')).toBe(false);
+
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(preview.style.height).toBe('300px');
+    expect(preview.classList.contains('drawio-interactive-viewport')).toBe(true);
+    expect(root.querySelector('.drawio-interactive-resize-handle')).not.toBeNull();
+    controller.dispose();
+  });
+
+  it('clamps the automatic height into the viewport bounds', () => {
+    const { preview, svg, controller } = fixture();
+    svg.setAttribute('viewBox', '0 0 2000 100'); // very flat diagram
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    controller.bindSvg(svg);
+    // 600 * 100 / 2000 = 30px proportional — clamped up to the 80px minimum.
+    expect(preview.style.height).toBe('80px');
+    controller.dispose();
+  });
+
+  it('anchors the resize handle to the preview wrapper, not the outer padded root', () => {
+    const root = document.body.createDiv({ cls: 'drawio-preview-file-view' });
+    const wrap = root.createDiv({ cls: 'drawio-preview-wrap' });
+    const preview = wrap.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const controller = new InteractiveViewerController(root, preview);
+    controller.bindSvg(svg);
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    expect(handle.parentElement).toBe(wrap);
+    controller.dispose();
+    expect(root.querySelector('.drawio-interactive-resize-handle')).toBeNull();
+  });
+
+  it('rebinds document-level listeners after the pane is adopted into another document', () => {
+    const { root, preview, controller } = fixture();
+    const popoutDoc = document.implementation.createHTMLDocument('popout');
+    popoutDoc.body.appendChild(root); // Obsidian adopts the pane DOM into the popout
+
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(true);
+
+    // The original document no longer controls the viewer...
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(controller.isActive).toBe(true);
+    // ...the adopting document does.
+    popoutDoc.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(controller.isActive).toBe(false);
+
+    // Click-outside works in the popout document too.
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(true);
+    popoutDoc.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(false);
+    controller.dispose();
+  });
+
+  it('ignores right-button presses for activation and panning', () => {
+    const { preview, controller } = fixture();
+    preview.dispatchEvent(new MouseEvent('pointerdown', {
+      bubbles: true, cancelable: true, button: 2, clientX: 50, clientY: 25,
+    }));
+    expect(controller.isActive).toBe(false);
+    controller.dispose();
+  });
+
+  it('deactivates even when a bubble-phase handler stops click propagation', () => {
+    const first = fixture();
+    const second = fixture();
+    // Embed roots stop propagation of their persistent click handler; the
+    // document-level click-outside listener must still see the click.
+    second.root.addEventListener('click', (event) => { event.stopPropagation(); });
+
+    first.preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(first.controller.isActive).toBe(true);
+
+    second.preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(second.controller.isActive).toBe(true);
+    expect(first.controller.isActive).toBe(false);
+    first.controller.dispose();
+    second.controller.dispose();
   });
 
   it('removes DOM and listeners when disposed', () => {

--- a/tests/interactiveViewer.dom.test.ts
+++ b/tests/interactiveViewer.dom.test.ts
@@ -683,6 +683,120 @@ describe('InteractiveViewerController walking skeleton', () => {
     controller.dispose();
   });
 
+  it('does not re-apply the viewport on window resize after the viewer is disabled', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    let enabled = true;
+    const controller = new InteractiveViewerController(root, preview, { isEnabled: () => enabled });
+    controller.bindSvg(svg); // jsdom measures 0 — stays deferred
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+
+    enabled = false;
+    window.dispatchEvent(new Event('resize'));
+    expect(preview.style.height).toBe('');
+    expect(preview.classList.contains('drawio-interactive-viewport')).toBe(false);
+
+    enabled = true;
+    window.dispatchEvent(new Event('resize'));
+    expect(preview.style.height).toBe('300px');
+    controller.dispose();
+  });
+
+  it('rebinds document listeners from the toolbar after a no-click popout adoption', () => {
+    const { root, preview, controller } = fixture();
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(controller.isActive).toBe(true);
+
+    // "Move to new window" relocates the pane without any prior interaction.
+    const popoutDoc = document.implementation.createHTMLDocument('popout');
+    popoutDoc.body.appendChild(root);
+    root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
+
+    // The original document lost control; the adopting one gained it.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(controller.isActive).toBe(true);
+    popoutDoc.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(controller.isActive).toBe(false);
+    controller.dispose();
+  });
+
+  it('judges the resize threshold by pointer travel and leaves the viewport untouched below it', () => {
+    const root = document.body.createDiv({ cls: 'drawio-codeblock' });
+    const preview = root.createDiv({ cls: 'drawio-preview' });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 100');
+    preview.appendChild(svg);
+    const onHeightCommit = vi.fn();
+    const controller = new InteractiveViewerController(root, preview, { onHeightCommit });
+    controller.bindSvg(svg);
+    vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 600, height: 300, right: 600, bottom: 300, x: 0, y: 0,
+      toJSON: () => ({}),
+    });
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    preview.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    root.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click();
+    frames.shift()!(0);
+    const zoomed = svg.getAttribute('viewBox');
+
+    // Simulate an out-of-range start height (SVG without usable viewBox
+    // metrics): a 1px wiggle must not let the clamp difference commit.
+    preview.style.height = '30px';
+    const handle = root.querySelector<HTMLElement>('.drawio-interactive-resize-handle')!;
+    handle.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientY: 100 }));
+    document.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientY: 101 }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientY: 101 }));
+
+    expect(onHeightCommit).not.toHaveBeenCalled();
+    expect(preview.style.height).toBe('30px'); // untouched — no clamp jump
+    expect(frames).toHaveLength(0); // no fit(): the zoom survives a click
+    expect(svg.getAttribute('viewBox')).toBe(zoomed);
+    controller.dispose();
+    raf.mockRestore();
+  });
+
+  it('initializes the deferred automatic height at the first real layout (ResizeObserver)', () => {
+    const callbacks: Array<() => void> = [];
+    const observed: Element[] = [];
+    const disconnect = vi.fn();
+    class FakeResizeObserver {
+      constructor(private cb: () => void) {
+        callbacks.push(() => { this.cb(); });
+      }
+      observe(el: Element): void { observed.push(el); }
+      disconnect = disconnect;
+      unobserve(): void { /* not used */ }
+    }
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+    try {
+      const { preview, controller } = fixture(); // width 0: defers, arms the observer
+      expect(observed).toContain(preview);
+      expect(preview.style.height).toBe('');
+
+      vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+        left: 0, top: 0, width: 600, height: 100, right: 600, bottom: 100, x: 0, y: 0,
+        toJSON: () => ({}),
+      });
+      callbacks[0]!();
+      expect(preview.style.height).toBe('300px');
+      expect(preview.classList.contains('drawio-interactive-viewport')).toBe(true);
+      expect(disconnect).toHaveBeenCalled();
+      controller.dispose();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('ignores right-button presses for activation and panning', () => {
     const { preview, controller } = fixture();
     preview.dispatchEvent(new MouseEvent('pointerdown', {

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -133,12 +133,44 @@ export class Setting {
   }
 }
 
-export class MarkdownRenderChild {
-  containerEl: HTMLElement;
-  constructor(containerEl: HTMLElement) { this.containerEl = containerEl; }
+// Mirrors obsidian's Component lifecycle contract: `load()` fires `onload`
+// once and cascades to children; `addChild` loads the child immediately when
+// the parent is already loaded; `unload()` runs children, `register`ed
+// callbacks, then `onunload`.
+export class Component {
+  private loaded = false;
+  private children: Component[] = [];
+  private unloadCallbacks: Array<() => void> = [];
+  load(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+    this.onload();
+    for (const child of this.children) child.load();
+  }
+  unload(): void {
+    if (!this.loaded) return;
+    this.loaded = false;
+    for (const child of this.children.splice(0)) child.unload();
+    for (const cb of this.unloadCallbacks.splice(0)) cb();
+    this.onunload();
+  }
+  addChild<T extends Component>(component: T): T {
+    this.children.push(component);
+    if (this.loaded) component.load();
+    return component;
+  }
+  register(cb: () => void): void { this.unloadCallbacks.push(cb); }
   registerEvent(_ref: unknown): void {}
   onload(): void {}
   onunload(): void {}
+}
+
+export class MarkdownRenderChild extends Component {
+  containerEl: HTMLElement;
+  constructor(containerEl: HTMLElement) {
+    super();
+    this.containerEl = containerEl;
+  }
 }
 
 /** Split "path#subpath" — subpath keeps its leading '#', '' when absent. */

--- a/tests/viewportHeight.test.ts
+++ b/tests/viewportHeight.test.ts
@@ -12,6 +12,12 @@ describe('viewport height Markdown metadata', () => {
     expect(parseViewportHeightComment('<!-- other: height=480 -->')).toBeNull();
   });
 
+  it('parses the comment behind blockquote markers and a trailing CR', () => {
+    expect(parseViewportHeightComment('> <!-- drawio-viewer: height=480 -->')).toBe(480);
+    expect(parseViewportHeightComment('> > <!-- drawio-viewer: height=200 -->')).toBe(200);
+    expect(parseViewportHeightComment('<!-- drawio-viewer: height=480 -->\r')).toBe(480);
+  });
+
   it('inserts a comment immediately before the selected code block', () => {
     const doc = ['before', '```drawio', '<mxfile/>', '```', 'after'].join('\n');
     expect(upsertViewportHeightComment(doc, 1, 480)).toBe(
@@ -40,5 +46,90 @@ describe('viewport height Markdown metadata', () => {
       '<mxfile/>',
       '```',
     ].join('\n'));
+  });
+
+  it('reproduces the callout prefix when inserting inside a blockquote', () => {
+    const doc = [
+      '> [!note] Diagram',
+      '> ![[diagram.drawio]]',
+      'after',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 1, 420)).toBe([
+      '> [!note] Diagram',
+      '> <!-- drawio-viewer: height=420 -->',
+      '> ![[diagram.drawio]]',
+      'after',
+    ].join('\n'));
+  });
+
+  it('reproduces nested blockquote markers and updates in place inside a callout', () => {
+    const inserted = upsertViewportHeightComment('> > ![[diagram.drawio]]', 0, 300);
+    expect(inserted).toBe('> > <!-- drawio-viewer: height=300 -->\n> > ![[diagram.drawio]]');
+    // Second write updates the existing prefixed comment instead of stacking.
+    expect(upsertViewportHeightComment(inserted!, 1, 350)).toBe(
+      '> > <!-- drawio-viewer: height=350 -->\n> > ![[diagram.drawio]]',
+    );
+  });
+
+  it('refuses to insert above a table row rather than corrupt the table', () => {
+    const doc = [
+      '| left | right |',
+      '| --- | --- |',
+      '| ![[diagram.drawio]] | text |',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 2, 480)).toBeNull();
+  });
+
+  it('refuses to insert above a table row inside a callout', () => {
+    const doc = [
+      '> | a | b |',
+      '> | - | - |',
+      '> | ![[diagram.drawio]] | x |',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 2, 480)).toBeNull();
+  });
+
+  it('refuses to insert directly above a list-item marker line', () => {
+    expect(upsertViewportHeightComment('- ![[diagram.drawio]]', 0, 480)).toBeNull();
+    expect(upsertViewportHeightComment('1. ![[diagram.drawio]]', 0, 480)).toBeNull();
+    expect(upsertViewportHeightComment('* ![[diagram.drawio]]', 0, 480)).toBeNull();
+  });
+
+  it('still updates an existing comment above a list item without restructuring', () => {
+    const doc = [
+      '<!-- drawio-viewer: height=200 -->',
+      '- ![[diagram.drawio]]',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 1, 260)).toBe([
+      '<!-- drawio-viewer: height=260 -->',
+      '- ![[diagram.drawio]]',
+    ].join('\n'));
+  });
+
+  it('keeps indentation for fences nested in list items', () => {
+    const doc = [
+      '- item',
+      '  ```drawio',
+      '  <mxfile/>',
+      '  ```',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 1, 480)).toBe([
+      '- item',
+      '  <!-- drawio-viewer: height=480 -->',
+      '  ```drawio',
+      '  <mxfile/>',
+      '  ```',
+    ].join('\n'));
+  });
+
+  it('preserves CRLF line endings when inserting and updating', () => {
+    const doc = 'before\r\n```drawio\r\n<mxfile/>\r\n```\r\nafter';
+    const inserted = upsertViewportHeightComment(doc, 1, 480);
+    expect(inserted).toBe(
+      'before\r\n<!-- drawio-viewer: height=480 -->\r\n```drawio\r\n<mxfile/>\r\n```\r\nafter',
+    );
+    expect(upsertViewportHeightComment(inserted!, 2, 520)).toBe(
+      'before\r\n<!-- drawio-viewer: height=520 -->\r\n```drawio\r\n<mxfile/>\r\n```\r\nafter',
+    );
   });
 });

--- a/tests/viewportHeight.test.ts
+++ b/tests/viewportHeight.test.ts
@@ -89,6 +89,40 @@ describe('viewport height Markdown metadata', () => {
     expect(upsertViewportHeightComment(doc, 2, 480)).toBeNull();
   });
 
+  it('refuses borderless GFM table rows (any unescaped pipe outside a wikilink)', () => {
+    expect(upsertViewportHeightComment('a | ![[diagram.drawio]] | b', 0, 480)).toBeNull();
+    expect(upsertViewportHeightComment('cell | ![[diagram.drawio]]', 0, 480)).toBeNull();
+  });
+
+  it('still writes for wikilink aliases and escaped pipes (not table delimiters)', () => {
+    expect(upsertViewportHeightComment('![[diagram.drawio|Architecture]]', 0, 480)).toBe(
+      '<!-- drawio-viewer: height=480 -->\n![[diagram.drawio|Architecture]]',
+    );
+    expect(upsertViewportHeightComment('price \\| note ![[diagram.drawio]]', 0, 480)).toBe(
+      '<!-- drawio-viewer: height=480 -->\nprice \\| note ![[diagram.drawio]]',
+    );
+  });
+
+  it('refuses the callout title line — the [!type] marker must stay on the first quote line', () => {
+    expect(upsertViewportHeightComment('> [!note] ![[diagram.drawio]]', 0, 480)).toBeNull();
+    expect(upsertViewportHeightComment('> > [!tip] ![[diagram.drawio]]', 0, 480)).toBeNull();
+    // Outside a blockquote `[!` is plain text, not a callout marker.
+    expect(upsertViewportHeightComment('[!not-a-callout] ![[diagram.drawio]]', 0, 480)).toBe(
+      '<!-- drawio-viewer: height=480 -->\n[!not-a-callout] ![[diagram.drawio]]',
+    );
+  });
+
+  it('keeps the existing comment line prefix when updating after the embed was de-quoted', () => {
+    const doc = [
+      '> <!-- drawio-viewer: height=300 -->',
+      '![[diagram.drawio]]',
+    ].join('\n');
+    expect(upsertViewportHeightComment(doc, 1, 350)).toBe([
+      '> <!-- drawio-viewer: height=350 -->',
+      '![[diagram.drawio]]',
+    ].join('\n'));
+  });
+
   it('refuses to insert directly above a list-item marker line', () => {
     expect(upsertViewportHeightComment('- ![[diagram.drawio]]', 0, 480)).toBeNull();
     expect(upsertViewportHeightComment('1. ![[diagram.drawio]]', 0, 480)).toBeNull();
@@ -120,6 +154,14 @@ describe('viewport height Markdown metadata', () => {
       '  <mxfile/>',
       '  ```',
     ].join('\n'));
+  });
+
+  it('inserts a CRLF comment above the final line of a CRLF note without a trailing newline', () => {
+    // The anchor itself carries no CR (it is the last line), but the inserted
+    // line is never file-final, so it must still match the file's CRLF style.
+    expect(upsertViewportHeightComment('a\r\n![[diagram.drawio]]', 1, 480)).toBe(
+      'a\r\n<!-- drawio-viewer: height=480 -->\r\n![[diagram.drawio]]',
+    );
   });
 
   it('preserves CRLF line endings when inserting and updating', () => {


### PR DESCRIPTION
Fixes all 15 checklist items from the PR #19 review findings. Closes #21.

## Note integrity (highest priority)

- **`viewportHeight.ts` — comment corrupts callout/list/table context**: `upsertViewportHeightComment` now reproduces the anchor line's blockquote/indentation prefix (`> `, nested `> > `, list-nested fence indents), so resizing inside a callout keeps the callout intact. When the embed sits in a table row or directly on a list-item marker line — where any inserted line would restructure the Markdown — the write is **refused** (new `unsupported` outcome, own Notice): not persisting is always preferable to damaging the note. Regression tests cover callout (incl. nested + update-in-place), table (incl. table-in-callout), and list cases.
- **`embedViewportHeight.ts` — DOM-occurrence fallback writes the wrong target under virtualization**: the occurrence-index tiebreaker is removed entirely. Only reliable signals remain, in order: Live Preview source offset → Reading-view section info → single unambiguous candidate; otherwise the write is refused as `ambiguous` with a Notice. Test updated to assert refusal where the old code guessed.
- **`interactiveViewer.ts` — zero-drag click on the resize handle writes the note**: the pointerdown height is recorded and `onHeightCommit` only fires when the height actually moved past a 2 px threshold. Plain clicks and sub-threshold wiggles no longer modify the file (regression-tested).

## Popout windows

- **`interactiveViewer.ts` — `ownerDocument` captured once at construction**: added `rebindIfDocumentChanged()` following the `DrawioEditor.rebindIfWindowChanged` pattern — document/window-level listeners (click-outside, Escape, fullscreenchange, resize, drag moves) follow the root's current document, checked at every element-bound entry point (those listeners travel with the adopted DOM). Event targets are duck-typed rather than `instanceof`-checked against one realm's `Node`. Regression test adopts the root into a second document and verifies old-document listeners are dead and new-document Escape/click-outside work.

## Interaction and lifecycle

- **Letterboxed zoom anchor drift**: cursor coordinates now map through the rendered content rectangle under `preserveAspectRatio="meet"` (uniform scale + centering offsets) before converting to viewBox units, for both wheel zoom and pan. Test pins the content point under an off-center cursor across a wheel step in a letterboxed viewport.
- **`initializeViewport` measures detached elements**: automatic sizing defers when the element measures zero width (detached code blocks / Reading-view sections) instead of falling back to raw viewBox units; activation, window resizes, and manual resizes initialize it once laid out. The automatic height is also clamped to the MIN/MAX viewport bounds (lower-severity note).
- **`EmbedRenderer` persistent click handler defeats click-outside**: the viewer's document-level click-outside listener now runs in the **capture phase**, so bubble-phase `stopPropagation` (our embed handler, other plugins) can no longer leave two viewers active. Test simulates a propagation-stopping root and asserts the first viewer deactivates.
- **Concurrent `render()` leaks controllers / fallback `addChild` after awaits**: `DrawioFileEmbed.render()` is generation-guarded — superseded renders bail after each await instead of constructing a second controller (test counts document listeners across overlapping renders). The fallback path registers a lifecycle child via `ctx.addChild` **before** any awaits and gates the interactive mount on the section still being loaded, so a torn-down section can never be handed an undisposable controller.
- **Toolbar zoom buttons reuse the 1.02 wheel micro-step**: discrete buttons now use a perceptible 1.25 step; the wheel keeps its fine step.
- **Persisted height ignored after switching the setting to Interactive viewer**: the lazily constructed controller reads the stored comment at first activation (`loadPersistedHeight`) — already-rendered previews now honor it without a re-render, in code blocks and both embed paths.
- **Unguarded `await readCodeBlockViewportHeight`**: wrapped in try/catch; a rejected read renders the diagram normally instead of leaving the block blank (regression test with a throwing vault).
- **Resize handle offset in the read-only file view**: the handle is anchored to the preview's positioned wrapper (`.drawio-preview-wrap`) instead of the padded outer root, putting it at the viewport's real bottom edge; unchanged for code blocks/embeds where the wrapper *is* the root.

## Performance and footprint

- **Controller constructed for every preview + global `user-select: none`**: new `mountInteractiveViewer` helper (shared by all four call sites) constructs the controller — five document/window listeners, `drawio-interactive` class — **only when the click action resolves to Interactive viewer**. Other modes install a single root-scoped click listener that constructs on first click after a settings switch, matching the previous "settings apply to existing previews" behavior while previews that never use the viewer pay nothing and keep normal text selection.
- **Vault `modify` triggers a full read per embed per keystroke**: the stored-height refresh is debounced (250 ms trailing) in both embed paths; a burst of edits coalesces into one read + locate (regression-tested with fake timers).

## Maintainability

- **`resolveBlockStart` duplicated the fence grammar**: `locateBlock.ts` gained `locateAllDrawioBlocks` (all-matches variant, now the single source of truth); `resolveBlockStart` consumes it.

## Lower-severity notes

Fixed alongside: the unnecessary `as unknown as` cast of `ctx.getSectionInfo`; the shadow `EmbedCacheItem` type (now obsidian's `EmbedCache`); the interactive-mount wiring copy-paste (unified in `mountInteractiveViewer`); `@codemirror/view` declared in devDependencies (still esbuild-external); CRLF notes (fence matching strips CR; inserted comments preserve CRLF); unclamped automatic height; right-click activating the viewer; disposing during fullscreen now exits fullscreen first.

Left as-is, with reasons:
- **Two embeds on one line share one height comment** — the comment grammar is line-based by design; teaching it column anchors is a format change out of scope here. The duplicate-disambiguation fix means the write targets the right line or refuses; distinct subpaths/lines remain the documented workaround.
- **Viewer inert when `renderPreview` takes its deferred MutationObserver path** — that path is a safety net that cannot trigger in practice: `check-visible-state: false` forces a synchronous render (see the `ViewerRenderer` header comment). Wiring a rebind through the observer would add coupling for an unreachable branch.
- Fenced code blocks *inside callouts* still don't persist heights (the fence grammar intentionally doesn't match `> `-prefixed fences) — but they now fail **safely** (no write) rather than corrupting; extending the grammar to quoted fences is a possible follow-up.

## Verification

- `npm test` — 47 files, 393 tests, all green (including the real-viewer suites).
- `npm run build` — clean (`tsc -noEmit` + esbuild production).
- All pre-existing behavior tests for editor/defaultApp/none click actions, multi-page controls, dual-format embeds (PR #23), and embed pinning pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
