### PR TITLE
fix(preview): centre the diagram in previews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,19 @@ name; the manifest id inside is `drawio-editor`).
   `tests/sanitizeViewer.test.ts` (parses + boots GraphViewer), and
   `tests/viewerBlobSafety.test.ts` gates the mobile-fatal regex constructs
   (see the regex checklist below); both skip when `viewer.min.txt` is absent.
+- **Previews shift the viewBox origin to re-centre the diagram**
+  (`ViewerRenderer.ts`, `VIEWBOX_CENTERING_SHIFT`). GraphViewer insets the
+  diagram by an 8px border but sizes the SVG as `bounds + 25`, so its own output
+  sits ~8 user units left of centre (measured: 13.4px vs 26.0px gutters on an
+  embed, 30.2 vs 58.5 on a code block). We emit `viewBox="-4 -4 w h"` — origin
+  shifted, size untouched — which equalises them exactly. **The shift is derived
+  from GraphViewer's constants, not chosen**: `tests/viewerBorderContract.dom.test.ts`
+  measures the border, the padding, and the half-pixel shape alignment off the
+  REAL vendored viewer and recomputes the shift from them, so a drawio bump that
+  moves any of the three fails loudly. Re-derive the shift then; don't relax the
+  test. Note `svg.getBBox()` is NOT a usable content bound here — it unions in a
+  zero-sized structural `<g>` at the origin and reports the diagram as far wider
+  and further left than it is.
 - **`svgSanitizer.ts` is a custom scrub, NOT DOMPurify.** DOMPurify strips
   `foreignObject`, which erases drawio's `html=1` text labels. Do **not** swap back to
   DOMPurify. It still removes script/embedding elements, `on*` handlers,

--- a/src/preview/ViewerRenderer.ts
+++ b/src/preview/ViewerRenderer.ts
@@ -120,6 +120,24 @@ export function renderPreview(el: HTMLElement, xml: string, opts: RenderOptions)
 }
 
 /**
+ * GraphViewer positions the diagram against an 8px top/left border but sizes the
+ * SVG as `bounds + 25`, so the right/bottom margins come out 8px wider than the
+ * left/top ones and the diagram sits visibly off-centre — ~1.4% of the width on a
+ * short code block. Shifting the viewBox ORIGIN by half that surplus re-centres it
+ * without touching the diagram or resizing the box.
+ *
+ * Both constants are GraphViewer's, not ours; tests/viewerBorderContract.dom.test.ts
+ * renders a known geometry through the REAL vendored viewer and fails if either one
+ * moves — that is the signal to re-derive this shift, not to relax the test.
+ */
+export const VIEWER_BORDER = 8;
+export const VIEWER_SIZE_PADDING = 25;
+/** (25 - 2*8) / 2 = 4.5 in GraphViewer's own terms, but its shapes land on a
+ *  half-pixel grid, which measures out as 8.5 / 16.5 gutters — so the shift that
+ *  actually equalises them is 4. */
+export const VIEWBOX_CENTERING_SHIFT = (VIEWER_SIZE_PADDING - 2 * VIEWER_BORDER - 1) / 2;
+
+/**
  * Sanitize GraphViewer's <svg> and make it self-contained: give it an explicit
  * `viewBox`/`width`/`height` from the diagram bounds (GraphViewer encodes those as
  * the SVG's `min-width`/`min-height`) and strip the inline `width:100%`/`height:100%`
@@ -147,7 +165,9 @@ function extractSizedSvg(svg: SVGSVGElement, targetDoc: Document): Node | null {
   if (!out) return null;
 
   if (w > 0 && h > 0) {
-    out.setAttribute('viewBox', `0 0 ${w} ${h}`);
+    // Shift the origin, not the size: same box, diagram centred inside it.
+    const origin = -VIEWBOX_CENTERING_SHIFT;
+    out.setAttribute('viewBox', `${origin} ${origin} ${w} ${h}`);
     out.setAttribute('width', String(w));
     out.setAttribute('height', String(h));
     // Inline width/height:100% (and absolute positioning) would override the

--- a/tests/viewerBorderContract.dom.test.ts
+++ b/tests/viewerBorderContract.dom.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  VIEWER_BORDER,
+  VIEWER_SIZE_PADDING,
+  VIEWBOX_CENTERING_SHIFT,
+} from '../src/preview/ViewerRenderer';
+
+/**
+ * Pins the three GraphViewer layout facts that VIEWBOX_CENTERING_SHIFT is
+ * derived from, by measuring them off the REAL vendored viewer:
+ *
+ *   1. it insets the diagram by an 8px border;
+ *   2. it sizes the SVG as `bounds + 25` (via `min-width`/`min-height`);
+ *   3. it half-pixel-aligns shapes (`translate(0.5,0.5)`).
+ *
+ * Because 25 > 2*8, the right/bottom margins end up wider than the left/top
+ * ones and the diagram sits off-centre; the shift is half that surplus. The
+ * final assertion closes the loop — it recomputes the shift from the measured
+ * numbers and compares it against the shipped constant, so a drawio bump that
+ * moves ANY of the three fails here.
+ *
+ * When it fails, re-derive the shift from the new values; do not relax the
+ * assertions. Skips when `npm run fetch-drawio` hasn't been run, matching the
+ * other suites that need the vendored blob.
+ *
+ * jsdom has no layout engine, but none is required: GraphViewer bakes the
+ * border straight into the shape's own coordinates there (rather than the root
+ * <g> transform it emits in a real browser), and both routes put the shape in
+ * the same place — so the constants are readable as plain attributes.
+ */
+const viewerPath = join(process.cwd(), 'src/preview/viewer.min.txt');
+const hasViewer = existsSync(viewerPath);
+
+const GEOM = { x: 400, y: 500, w: 120, h: 60 };
+const XML =
+  '<mxfile><diagram id="d" name="P"><mxGraphModel dx="0" dy="0" grid="0" '
+  + 'page="1" pageWidth="850" pageHeight="1100"><root>'
+  + '<mxCell id="0"/><mxCell id="1" parent="0"/>'
+  + '<mxCell id="2" value="Box" style="rounded=0" vertex="1" parent="1">'
+  + `<mxGeometry x="${GEOM.x}" y="${GEOM.y}" width="${GEOM.w}" height="${GEOM.h}" as="geometry"/>`
+  + '</mxCell></root></mxGraphModel></diagram></mxfile>';
+
+describe.skipIf(!hasViewer)('GraphViewer border/size contract', () => {
+  let svg: SVGSVGElement;
+  let shape: SVGRectElement;
+
+  beforeAll(() => {
+    const win = window as unknown as Record<string, unknown> & { eval: (c: string) => void };
+    // Same offline pre-flight as loadViewer.ts, so the viewer neither fetches
+    // resources nor auto-scans the document on load.
+    win.mxLoadResources = false;
+    win.mxLoadStylesheets = false;
+    win.mxForceIncludes = false;
+    win.STYLE_PATH = '.';
+    win.RESOURCE_BASE = '.';
+    win.mxBasePath = '.';
+    win.PROXY_URL = '';
+    win.onDrawioViewerLoad = (): void => { /* no-op */ };
+    win.eval(readFileSync(viewerPath, 'utf8'));
+
+    const mount = document.createElement('div');
+    mount.className = 'mxgraph';
+    mount.setAttribute('data-mxgraph', JSON.stringify({
+      highlight: '#0000ff', nav: false, lightbox: false, toolbar: '', edit: null,
+      'check-visible-state': false, 'dark-mode': 'off', page: 0, xml: XML,
+    }));
+    document.body.appendChild(mount);
+    (win.GraphViewer as { createViewerForElement(el: HTMLElement): void })
+      .createViewerForElement(mount);
+
+    svg = mount.querySelector('svg')!;
+    // The vertex: the only <rect> carrying the geometry's own width.
+    shape = Array.from(svg.querySelectorAll('rect'))
+      .find((r) => r.getAttribute('width') === String(GEOM.w))!;
+  });
+
+  it('insets the diagram by the border', () => {
+    expect(shape, 'no rect matching the vertex geometry').toBeTruthy();
+    expect(Number(shape.getAttribute('x'))).toBe(VIEWER_BORDER);
+    expect(Number(shape.getAttribute('y'))).toBe(VIEWER_BORDER);
+  });
+
+  it('sizes the svg as bounds plus the padding', () => {
+    expect(parseFloat(svg.style.minWidth)).toBe(GEOM.w + VIEWER_SIZE_PADDING);
+    expect(parseFloat(svg.style.minHeight)).toBe(GEOM.h + VIEWER_SIZE_PADDING);
+  });
+
+  it('half-pixel-aligns shapes', () => {
+    expect(halfPixelOffset()).toBe(0.5);
+  });
+
+  // The loop-closing check: derive the shift from what was just measured.
+  it('agrees with the shipped centering shift', () => {
+    const border = Number(shape.getAttribute('x'));
+    const padding = parseFloat(svg.style.minWidth) - GEOM.w;
+    const align = halfPixelOffset();
+    const left = border + align;
+    const right = padding - border - align;
+    expect(VIEWBOX_CENTERING_SHIFT).toBe((right - left) / 2);
+  });
+
+  /** The `translate(0.5,0.5)` GraphViewer wraps shapes in, or 0 if it stops. */
+  function halfPixelOffset(): number {
+    for (const g of Array.from(svg.querySelectorAll('g[transform]'))) {
+      const m = /^translate\(\s*([\d.]+)\s*,\s*([\d.]+)\s*\)$/.exec(
+        g.getAttribute('transform') ?? '');
+      if (m && m[1] === m[2]) return Number(m[1]);
+    }
+    return 0;
+  }
+});

--- a/tests/viewerRenderer.sizing.test.ts
+++ b/tests/viewerRenderer.sizing.test.ts
@@ -18,7 +18,7 @@ vi.mock('../src/preview/loadViewer', () => ({
   getGraphViewer: () => fakeViewer,
 }));
 
-import { renderPreview } from '../src/preview/ViewerRenderer';
+import { renderPreview, VIEWBOX_CENTERING_SHIFT } from '../src/preview/ViewerRenderer';
 
 function patchEl(el: HTMLElement) {
   (el as any).empty = function () { while (this.firstChild) this.removeChild(this.firstChild); };
@@ -42,8 +42,12 @@ describe('renderPreview standalone-svg sizing', () => {
 
     const svg = el.querySelector('svg');
     expect(svg).toBeTruthy();
-    // Bounds come from the GraphViewer min-width/min-height (185x85).
-    expect(svg!.getAttribute('viewBox')).toBe('0 0 185 85');
+    // Size comes from the GraphViewer min-width/min-height (185x85); the origin
+    // is shifted negative to re-centre the diagram, which GraphViewer itself
+    // leaves 8px left-of-centre (see VIEWBOX_CENTERING_SHIFT and
+    // tests/viewerBorderContract.dom.test.ts).
+    const o = -VIEWBOX_CENTERING_SHIFT;
+    expect(svg!.getAttribute('viewBox')).toBe(`${o} ${o} 185 85`);
     expect(svg!.getAttribute('width')).toBe('185');
     expect(svg!.getAttribute('height')).toBe('85');
     // The inline width/height:100% (which would stretch a standalone svg) is gone.


### PR DESCRIPTION
## Why

Every preview sits slightly left of centre. Measured in a real vault, gutters were:

| | left | right | off by |
|---|---|---|---|
| embed | 13.4 px | 26.0 px | 12.6 px (0.61% of width) |
| code block | 30.2 px | 58.5 px | 28.4 px (1.37%) |

The cause is in GraphViewer, and we inherited it: it insets the diagram by an **8px border** but sizes the SVG as **bounds + 25**. Since 25 > 2×8, the right/bottom margins come out 8 user units wider than the left/top ones. `extractSizedSvg` took `min-width`/`min-height` as the viewBox size while leaving the origin at `0 0`, carrying the skew straight through.

## What

Emit `viewBox="-4 -4 w h"` — the origin moves by half the surplus, the box keeps its size, the diagram lands centred. Nothing else changes: no CSS, no interactive-viewer logic, no diagram coordinates.

The shift is derived, not picked:

```
VIEWBOX_CENTERING_SHIFT = (VIEWER_SIZE_PADDING - 2*VIEWER_BORDER - 1) / 2 = 4
```

(the `-1` is GraphViewer's half-pixel shape alignment, 0.5 on each side).

## The assertion

`tests/viewerBorderContract.dom.test.ts` renders a known geometry through the **real vendored viewer**, measures all three facts — border, padding, half-pixel alignment — then recomputes the shift and compares it against the shipped constant. A drawio bump that moves any of them fails there instead of silently skewing previews again.

Verified by fault injection: changing `VIEWER_SIZE_PADDING` to 30 fails two assertions (`expected 145 to be 150`, `expected 6.5 to be 4`). Skips when `viewer.min.txt` is absent, matching the other viewer suites.

## Result

Same vault, same previews, after the change:

| | left | right | off by |
|---|---|---|---|
| embed | 19.7 px | 19.7 px | **0** |
| code block | 44.3 px | 44.3 px | **0** |

436 tests pass, `tsc` clean.

## One trap worth knowing about

`svg.getBBox()` is unusable as a content bound on these SVGs — it unions in a zero-sized structural `<g>` at the origin and reports the diagram as both far wider and far further left than it is. It initially read as a 44% horizontal clip that does not exist. Measuring the painted leaf nodes and mapping them through `getScreenCTM()` gives numbers that reconcile exactly with the geometry in the `.drawio` XML. Recorded in CLAUDE.md so the next investigation doesn't repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
